### PR TITLE
fix: populate spaceId and environment during content type ImportState

### DIFF
--- a/internal/resources/contenttype/resource.go
+++ b/internal/resources/contenttype/resource.go
@@ -563,6 +563,8 @@ func (e *contentTypeResource) ImportState(ctx context.Context, request resource.
 
 	state := &ContentType{}
 	state.Import(resp.JSON200)
+	state.SpaceId = types.StringValue(spaceId)
+	state.Environment = types.StringValue(environment)
 
 	// Set refreshed state
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)


### PR DESCRIPTION
### What does this PR fix?

Fixes an issue in the `ImportState` function of the `contentType` resource, where after running `terraform import`, the `Read()` function fails because `spaceId` and `environment` are not properly set in the resource state.

### Changes introduced

In the `ImportState()` function of the `contentType` resource (`internal/resources/contenttype/resource.go`), this PR explicitly sets `spaceId`, `environment`, and `id` in the resource state. This ensures they are correctly populated and available during the `Read()` lifecycle step.

### Example

```bash
terraform import contentful_contenttype.mytype mytype:environment:spaceId
```

### Previously:

- state.SpaceId.ValueString() returned empty
- state.Environment.ValueString() returned empty

### Now:

- All fields (spaceId, environment) are correctly set in the state, allowing the resource to function properly after the import.

### Impact
Without this fix, a resource imported via Terraform cannot be read or managed correctly due to missing required state values, breaking the expected terraform import workflow.