### PR TITLE
feat: added contenttype support for validations on embedded RichText nodes

### DIFF
--- a/.changes/unreleased/Added-20250606-114756.yaml
+++ b/.changes/unreleased/Added-20250606-114756.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added contenttype support for validations on embedded RichText nodes
+time: 2025-06-06T11:47:56.017453499+02:00

--- a/docs/resources/contenttype.md
+++ b/docs/resources/contenttype.md
@@ -13,6 +13,22 @@ Todo for explaining contenttype
 ## Example Usage
 
 ```terraform
+resource "contentful_contenttype" "some_other_content_type" {
+  space_id      = "space-id"
+  environment   = "provider-test"
+  id            = "some_other_content_type"
+  name          = "some_other_content_type"
+  description   = "some other content type description"
+  display_field = "content"
+
+  fields = [{
+    id       = "content"
+    name     = "Content"
+    type     = "RichText"
+    required = true
+  }]
+}
+
 resource "contentful_contenttype" "example_contenttype" {
   space_id      = "space-id"
   environment   = "master"
@@ -59,6 +75,33 @@ resource "contentful_contenttype" "example_contenttype" {
           ]
         }
       ]
+    },
+    {
+      id   = "content"
+      name = "Content"
+      type = "RichText"
+      validations = [
+        {
+          nodes = {
+            entry_hyperlink = [
+              {
+                size = {
+                  min = 1
+                  max = 1
+                },
+                message = "test",
+              },
+              {
+                link_content_type = [
+                  contentful_contenttype.some_other_content_type.id
+                ],
+                message = "test"
+              },
+            ]
+          }
+        }
+      ]
+      required = false
     }
   ]
 }
@@ -158,7 +201,8 @@ Optional:
 - `in` (List of String)
 - `link_content_type` (List of String)
 - `link_mimetype_group` (List of String)
-- `message` (String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `nodes` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--nodes))
 - `range` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--range))
 - `regexp` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--regexp))
 - `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--size))
@@ -171,6 +215,201 @@ Optional:
 
 - `max` (Number)
 - `min` (Number)
+
+
+<a id="nestedatt--fields--items--validations--nodes"></a>
+### Nested Schema for `fields.items.validations.nodes`
+
+Optional:
+
+- `asset_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--asset_hyperlink))
+- `embedded_asset_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_asset_block))
+- `embedded_entry_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_entry_block))
+- `embedded_entry_inline` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_entry_inline))
+- `embedded_resource_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_block))
+- `embedded_resource_inline` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_inline))
+- `entry_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--entry_hyperlink))
+- `resource_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--items--validations--unique--resource_hyperlink))
+
+<a id="nestedatt--fields--items--validations--unique--asset_hyperlink"></a>
+### Nested Schema for `fields.items.validations.unique.asset_hyperlink`
+
+Optional:
+
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--asset_hyperlink--size))
+
+<a id="nestedatt--fields--items--validations--unique--asset_hyperlink--size"></a>
+### Nested Schema for `fields.items.validations.unique.asset_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_asset_block"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_asset_block`
+
+Optional:
+
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_asset_block--size))
+
+<a id="nestedatt--fields--items--validations--unique--embedded_asset_block--size"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_asset_block.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_entry_block"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_entry_block`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_entry_block--size))
+
+<a id="nestedatt--fields--items--validations--unique--embedded_entry_block--size"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_entry_block.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_entry_inline"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_entry_inline`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_entry_inline--size))
+
+<a id="nestedatt--fields--items--validations--unique--embedded_entry_inline--size"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_entry_inline.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_block"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_block`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_block--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_block--size))
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_block--allowed_resources"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_block.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_block--size"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_block.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_inline"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_inline`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_inline--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--embedded_resource_inline--size))
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_inline--allowed_resources"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_inline.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--items--validations--unique--embedded_resource_inline--size"></a>
+### Nested Schema for `fields.items.validations.unique.embedded_resource_inline.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--entry_hyperlink"></a>
+### Nested Schema for `fields.items.validations.unique.entry_hyperlink`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--entry_hyperlink--size))
+
+<a id="nestedatt--fields--items--validations--unique--entry_hyperlink--size"></a>
+### Nested Schema for `fields.items.validations.unique.entry_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--items--validations--unique--resource_hyperlink"></a>
+### Nested Schema for `fields.items.validations.unique.resource_hyperlink`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--items--validations--unique--resource_hyperlink--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--items--validations--unique--resource_hyperlink--size))
+
+<a id="nestedatt--fields--items--validations--unique--resource_hyperlink--allowed_resources"></a>
+### Nested Schema for `fields.items.validations.unique.resource_hyperlink.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--items--validations--unique--resource_hyperlink--size"></a>
+### Nested Schema for `fields.items.validations.unique.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
 
 
 <a id="nestedatt--fields--items--validations--range"></a>
@@ -212,7 +451,8 @@ Optional:
 - `in` (List of String)
 - `link_content_type` (List of String)
 - `link_mimetype_group` (List of String)
-- `message` (String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `nodes` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes))
 - `range` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--range))
 - `regexp` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--regexp))
 - `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--size))
@@ -225,6 +465,201 @@ Optional:
 
 - `max` (Number)
 - `min` (Number)
+
+
+<a id="nestedatt--fields--validations--nodes"></a>
+### Nested Schema for `fields.validations.nodes`
+
+Optional:
+
+- `asset_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--asset_hyperlink))
+- `embedded_asset_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--embedded_asset_block))
+- `embedded_entry_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--embedded_entry_block))
+- `embedded_entry_inline` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--embedded_entry_inline))
+- `embedded_resource_block` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--embedded_resource_block))
+- `embedded_resource_inline` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--embedded_resource_inline))
+- `entry_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--entry_hyperlink))
+- `resource_hyperlink` (Attributes List) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink))
+
+<a id="nestedatt--fields--validations--nodes--asset_hyperlink"></a>
+### Nested Schema for `fields.validations.nodes.asset_hyperlink`
+
+Optional:
+
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--embedded_asset_block"></a>
+### Nested Schema for `fields.validations.nodes.embedded_asset_block`
+
+Optional:
+
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--embedded_entry_block"></a>
+### Nested Schema for `fields.validations.nodes.embedded_entry_block`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--embedded_entry_inline"></a>
+### Nested Schema for `fields.validations.nodes.embedded_entry_inline`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--embedded_resource_block"></a>
+### Nested Schema for `fields.validations.nodes.embedded_resource_block`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--embedded_resource_inline"></a>
+### Nested Schema for `fields.validations.nodes.embedded_resource_inline`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--entry_hyperlink"></a>
+### Nested Schema for `fields.validations.nodes.entry_hyperlink`
+
+Optional:
+
+- `link_content_type` (List of String)
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink`
+
+Optional:
+
+- `allowed_resources` (Attributes List) Defines the entities that can be referenced by the field. It is only used for cross-space references. (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources))
+- `message` (String) Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.
+- `size` (Attributes) (see [below for nested schema](#nestedatt--fields--validations--nodes--resource_hyperlink--size))
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--allowed_resources"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.allowed_resources`
+
+Optional:
+
+- `content_types` (List of String)
+- `source` (String)
+- `type` (String)
+
+
+<a id="nestedatt--fields--validations--nodes--resource_hyperlink--size"></a>
+### Nested Schema for `fields.validations.nodes.resource_hyperlink.size`
+
+Optional:
+
+- `max` (Number)
+- `min` (Number)
+
+
 
 
 <a id="nestedatt--fields--validations--range"></a>

--- a/examples/resources/contentful_contenttype/resource.tf
+++ b/examples/resources/contentful_contenttype/resource.tf
@@ -1,3 +1,19 @@
+resource "contentful_contenttype" "some_other_content_type" {
+  space_id      = "space-id"
+  environment   = "provider-test"
+  id            = "some_other_content_type"
+  name          = "some_other_content_type"
+  description   = "some other content type description"
+  display_field = "content"
+
+  fields = [{
+    id       = "content"
+    name     = "Content"
+    type     = "RichText"
+    required = true
+  }]
+}
+
 resource "contentful_contenttype" "example_contenttype" {
   space_id      = "space-id"
   environment   = "master"
@@ -44,6 +60,33 @@ resource "contentful_contenttype" "example_contenttype" {
           ]
         }
       ]
+    },
+    {
+      id   = "content"
+      name = "Content"
+      type = "RichText"
+      validations = [
+        {
+          nodes = {
+            entry_hyperlink = [
+              {
+                size = {
+                  min = 1
+                  max = 1
+                },
+                message = "test",
+              },
+              {
+                link_content_type = [
+                  contentful_contenttype.some_other_content_type.id
+                ],
+                message = "test"
+              },
+            ]
+          }
+        }
+      ]
+      required = false
     }
   ]
 }

--- a/internal/resources/contenttype/resource.go
+++ b/internal/resources/contenttype/resource.go
@@ -61,7 +61,6 @@ var arrayItemTypes = []string{"Symbol", "Link", "ResourceLink"}
 //https://www.contentful.com/developers/docs/extensibility/app-framework/editor-interfaces/
 
 func (e *contentTypeResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
-
 	sizeSchema := schema.SingleNestedAttribute{
 		Optional: true,
 		Attributes: map[string]schema.Attribute{
@@ -70,6 +69,35 @@ func (e *contentTypeResource) Schema(ctx context.Context, request resource.Schem
 			},
 			"max": schema.Float64Attribute{
 				Optional: true,
+			},
+		},
+	}
+
+	linkContentTypeSchema := schema.ListAttribute{
+		Optional:    true,
+		ElementType: types.StringType,
+	}
+
+	messageSchema := schema.StringAttribute{
+		MarkdownDescription: "Defines the message that is shown to the user when the validation fails. It can be used to provide more information about the validation.",
+		Optional:            true,
+	}
+
+	allowedResourcesSchema := schema.ListNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: "Defines the entities that can be referenced by the field. It is only used for cross-space references.",
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{
+					Optional: true,
+				},
+				"source": schema.StringAttribute{
+					Optional: true,
+				},
+				"content_types": schema.ListAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+				},
 			},
 		},
 	}
@@ -96,10 +124,7 @@ func (e *contentTypeResource) Schema(ctx context.Context, request resource.Schem
 					Optional:    true,
 					ElementType: types.StringType,
 				},
-				"link_content_type": schema.ListAttribute{
-					Optional:    true,
-					ElementType: types.StringType,
-				},
+				"link_content_type": linkContentTypeSchema,
 				"in": schema.ListAttribute{
 					Optional:    true,
 					ElementType: types.StringType,
@@ -112,8 +137,104 @@ func (e *contentTypeResource) Schema(ctx context.Context, request resource.Schem
 					Optional:    true,
 					ElementType: types.StringType,
 				},
-				"message": schema.StringAttribute{
+				"message": messageSchema,
+				"nodes": schema.SingleNestedAttribute{
 					Optional: true,
+					Attributes: map[string]schema.Attribute{
+						"asset_hyperlink": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"size":    sizeSchema,
+									"message": messageSchema,
+								},
+							},
+						},
+						"entry_hyperlink": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"size":              sizeSchema,
+									"link_content_type": linkContentTypeSchema,
+									"message":           messageSchema,
+								},
+							},
+						},
+						"embedded_asset_block": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"size":    sizeSchema,
+									"message": messageSchema,
+								},
+							},
+						},
+						"embedded_entry_block": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"size":              sizeSchema,
+									"link_content_type": linkContentTypeSchema,
+									"message":           messageSchema,
+								},
+							},
+						},
+						"embedded_entry_inline": schema.ListNestedAttribute{
+							Optional: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"size":              sizeSchema,
+									"message":           messageSchema,
+									"link_content_type": linkContentTypeSchema,
+								},
+							},
+						},
+						"embedded_resource_block": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"validations": schema.ListNestedAttribute{
+									Optional: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"size":    sizeSchema,
+											"message": messageSchema,
+										},
+									},
+								},
+								"allowed_resources": allowedResourcesSchema,
+							},
+						},
+						"embedded_resource_inline": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"validations": schema.ListNestedAttribute{
+									Optional: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"size":    sizeSchema,
+											"message": messageSchema,
+										},
+									},
+								},
+								"allowed_resources": allowedResourcesSchema,
+							},
+						},
+						"resource_hyperlink": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"validations": schema.ListNestedAttribute{
+									Optional: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"size":    sizeSchema,
+											"message": messageSchema,
+										},
+									},
+								},
+								"allowed_resources": allowedResourcesSchema,
+							},
+						},
+					},
 				},
 			},
 			Validators: []validator.Object{

--- a/internal/sdk/main.gen.go
+++ b/internal/sdk/main.gen.go
@@ -203,6 +203,13 @@ const (
 	WebhookCollectionSysTypeArray WebhookCollectionSysType = "Array"
 )
 
+// AllowedResource defines model for AllowedResource.
+type AllowedResource struct {
+	ContentTypes *[]string `json:"contentTypes,omitempty"`
+	Source       *string   `json:"source,omitempty"`
+	Type         *string   `json:"type,omitempty"`
+}
+
 // ApiKey defines model for ApiKey.
 type ApiKey struct {
 	// AccessToken The Content Delivery API access token
@@ -524,6 +531,12 @@ type AssetFile struct {
 	Upload string `json:"upload"`
 }
 
+// AssetHyperlinkValidation defines model for AssetHyperlinkValidation.
+type AssetHyperlinkValidation struct {
+	Message *string      `json:"message,omitempty"`
+	Size    *RangeMinMax `json:"size,omitempty"`
+}
+
 // ContentType defines model for ContentType.
 type ContentType struct {
 	// Description Description of the content type
@@ -676,6 +689,44 @@ type EditorInterfaceUpdate struct {
 	Sidebar       *[]EditorInterfaceSidebarItem `json:"sidebar,omitempty"`
 }
 
+// EmbeddedAssetBlockValidation defines model for EmbeddedAssetBlockValidation.
+type EmbeddedAssetBlockValidation struct {
+	Message *string      `json:"message,omitempty"`
+	Size    *RangeMinMax `json:"size,omitempty"`
+}
+
+// EmbeddedEntryBlockValidation defines model for EmbeddedEntryBlockValidation.
+type EmbeddedEntryBlockValidation struct {
+	LinkContentType *[]string    `json:"linkContentType,omitempty"`
+	Message         *string      `json:"message,omitempty"`
+	Size            *RangeMinMax `json:"size,omitempty"`
+}
+
+// EmbeddedEntryInlineValidation defines model for EmbeddedEntryInlineValidation.
+type EmbeddedEntryInlineValidation struct {
+	LinkContentType *[]string    `json:"linkContentType,omitempty"`
+	Message         *string      `json:"message,omitempty"`
+	Size            *RangeMinMax `json:"size,omitempty"`
+}
+
+// EmbeddedResourceBlockValidation defines model for EmbeddedResourceBlockValidation.
+type EmbeddedResourceBlockValidation struct {
+	AllowedResources *[]AllowedResource    `json:"allowedResources,omitempty"`
+	Validations      *[]EmbeddedValidation `json:"validations,omitempty"`
+}
+
+// EmbeddedResourceInlineValidation defines model for EmbeddedResourceInlineValidation.
+type EmbeddedResourceInlineValidation struct {
+	AllowedResources *[]AllowedResource    `json:"allowedResources,omitempty"`
+	Validations      *[]EmbeddedValidation `json:"validations,omitempty"`
+}
+
+// EmbeddedValidation defines model for EmbeddedValidation.
+type EmbeddedValidation struct {
+	Message *string      `json:"message,omitempty"`
+	Size    *RangeMinMax `json:"size,omitempty"`
+}
+
 // Entry defines model for Entry.
 type Entry struct {
 	// Fields Content fields with values by locale
@@ -707,6 +758,13 @@ type EntryCollectionSysType string
 type EntryDraft struct {
 	// Fields Content fields with values by locale
 	Fields *orderedmap.OrderedMap `json:"fields,omitempty"`
+}
+
+// EntryHyperlinkValidation defines model for EntryHyperlinkValidation.
+type EntryHyperlinkValidation struct {
+	LinkContentType *[]string    `json:"linkContentType,omitempty"`
+	Message         *string      `json:"message,omitempty"`
+	Size            *RangeMinMax `json:"size,omitempty"`
 }
 
 // Environment defines model for Environment.
@@ -877,6 +935,7 @@ type FieldValidation struct {
 
 	// Message Custom error message
 	Message *string               `json:"message,omitempty"`
+	Nodes   *NodesValidation      `json:"nodes,omitempty"`
 	Range   *RangeMinMax          `json:"range,omitempty"`
 	Regexp  *RegexValidationValue `json:"regexp,omitempty"`
 	Size    *RangeMinMax          `json:"size,omitempty"`
@@ -973,6 +1032,18 @@ type LocaleUpdate struct {
 
 	// Optional Whether this locale is optional for content
 	Optional *bool `json:"optional,omitempty"`
+}
+
+// NodesValidation defines model for NodesValidation.
+type NodesValidation struct {
+	AssetHyperlink         *[]AssetHyperlinkValidation       `json:"asset-hyperlink,omitempty"`
+	EmbeddedAssetBlock     *[]EmbeddedAssetBlockValidation   `json:"embedded-asset-block,omitempty"`
+	EmbeddedEntryBlock     *[]EmbeddedEntryBlockValidation   `json:"embedded-entry-block,omitempty"`
+	EmbeddedEntryInline    *[]EmbeddedEntryInlineValidation  `json:"embedded-entry-inline,omitempty"`
+	EmbeddedResourceBlock  *EmbeddedResourceBlockValidation  `json:"embedded-resource-block,omitempty"`
+	EmbeddedResourceInline *EmbeddedResourceInlineValidation `json:"embedded-resource-inline,omitempty"`
+	EntryHyperlink         *[]EntryHyperlinkValidation       `json:"entry-hyperlink,omitempty"`
+	ResourceHyperlink      *ResourceHyperlinkValidation      `json:"resource-hyperlink,omitempty"`
 }
 
 // PreviewApiKey defines model for PreviewApiKey.
@@ -1089,6 +1160,12 @@ type RegexValidationValue struct {
 
 	// Pattern Regular expression pattern
 	Pattern string `json:"pattern"`
+}
+
+// ResourceHyperlinkValidation defines model for ResourceHyperlinkValidation.
+type ResourceHyperlinkValidation struct {
+	AllowedResources *[]AllowedResource    `json:"allowedResources,omitempty"`
+	Validations      *[]EmbeddedValidation `json:"validations,omitempty"`
 }
 
 // Space defines model for Space.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1852,6 +1852,146 @@ components:
         message:
           type: string
           description: Custom error message
+        nodes:
+          $ref: '#/components/schemas/NodesValidation'
+
+    AssetHyperlinkValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        message:
+          type: string
+
+    EmbeddedAssetBlockValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        message:
+          type: string
+
+    EmbeddedEntryBlockValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        linkContentType:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+
+    EmbeddedEntryInlineValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        linkContentType:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+
+    EntryHyperlinkValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        linkContentType:
+          type: array
+          items:
+            type: string
+        message:
+          type: string
+
+    EmbeddedResourceBlockValidation:
+      type: object
+      properties:
+        validations:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedValidation'
+        allowedResources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllowedResource'
+
+    EmbeddedResourceInlineValidation:
+      type: object
+      properties:
+        validations:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedValidation'
+        allowedResources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllowedResource'
+
+    ResourceHyperlinkValidation:
+      type: object
+      properties:
+        validations:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedValidation'
+        allowedResources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AllowedResource'
+
+    EmbeddedValidation:
+      type: object
+      properties:
+        size:
+          $ref: '#/components/schemas/RangeMinMax'
+        message:
+          type: string
+
+    NodesValidation:
+      type: object
+      properties:
+        asset-hyperlink:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetHyperlinkValidation'
+        embedded-asset-block:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedAssetBlockValidation'
+        embedded-entry-block:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedEntryBlockValidation'
+        embedded-entry-inline:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmbeddedEntryInlineValidation'
+        entry-hyperlink:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntryHyperlinkValidation'
+        embedded-resource-block:
+          $ref: '#/components/schemas/EmbeddedResourceBlockValidation'
+        embedded-resource-inline:
+          $ref: '#/components/schemas/EmbeddedResourceInlineValidation'
+        resource-hyperlink:
+          $ref: '#/components/schemas/ResourceHyperlinkValidation'
+
+    AllowedResource:
+      type: object
+      properties:
+        type:
+          type: string
+        source:
+          type: string
+        contentTypes:
+          type: array
+          items:
+            type: string
 
     RangeDate:
       type: object


### PR DESCRIPTION
This pull request introduces support for validations on embedded RichText nodes in Contentful content types. The changes include updates to the schema definitions, documentation, and examples, as well as modifications to the internal model and validation logic to accommodate the new `nodes` attribute.

### Documentation Updates:
* Added examples and explanations for the new `nodes` attribute in `docs/resources/contenttype.md`. This includes nested schemas for various node types such as `entry_hyperlink`, `embedded_asset_block`, and `embedded_entry_inline`. [[1]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0R220-R324) [[2]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0R380-R484)

### Schema and Validation Enhancements:
* Updated the `Validation` struct in `internal/resources/contenttype/model.go` to include a new `Nodes` attribute, along with its nested validation types. Implemented logic to handle `Nodes` in the `Draft` and `getValidation` methods. [[1]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaR82) [[2]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaR167-R172) [[3]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaR883-R1007)
* Added new types and methods to process and convert `Nodes` validations, including mapping attributes like `size` and `link_content_type` for various node types.

### Examples:
* Updated `examples/resources/contentful_contenttype/resource.tf` to demonstrate the usage of `nodes` validations with a `RichText` field. [[1]](diffhunk://#diff-851ef8dd86b8c0ad6fd82091545f8d08000fa642723ca8a1138e4133a22bca19R1-R16) [[2]](diffhunk://#diff-851ef8dd86b8c0ad6fd82091545f8d08000fa642723ca8a1138e4133a22bca19R63-R89)

### Change Metadata:
* Added a changelog entry in `.changes/unreleased/Added-20250606-114756.yaml` to document the addition of content type support for validations on embedded RichText nodes.