### PR TITLE
fix: interpretation of slice nil pointer instead of empty slice in validation draft

### DIFF
--- a/.changes/unreleased/Fixed-20250613-100705.yaml
+++ b/.changes/unreleased/Fixed-20250613-100705.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed contenttype validation interpretation of slice nill pointer instead of empty slice
+time: 2025-06-13T10:07:05.376465096+02:00

--- a/internal/resources/contenttype/model.go
+++ b/internal/resources/contenttype/model.go
@@ -123,7 +123,7 @@ func (v Validation) Draft() (*sdk.FieldValidation, error) {
 		return base, nil
 	}
 
-	if len(v.LinkContentType) > 0 {
+	if v.LinkContentType != nil {
 		value := pie.Map(v.LinkContentType, func(t types.String) string {
 			return t.ValueString()
 		})
@@ -131,7 +131,7 @@ func (v Validation) Draft() (*sdk.FieldValidation, error) {
 		return base, nil
 	}
 
-	if len(v.LinkMimetypeGroup) > 0 {
+	if v.LinkMimetypeGroup != nil {
 		value := pie.Map(v.LinkMimetypeGroup, func(t types.String) string {
 			return t.ValueString()
 		})
@@ -139,7 +139,7 @@ func (v Validation) Draft() (*sdk.FieldValidation, error) {
 		return base, nil
 	}
 
-	if len(v.In) > 0 {
+	if v.In != nil {
 		value := pie.Map(v.In, func(t types.String) string {
 			return t.ValueString()
 		})
@@ -147,7 +147,7 @@ func (v Validation) Draft() (*sdk.FieldValidation, error) {
 		return base, nil
 	}
 
-	if len(v.EnabledMarks) > 0 {
+	if v.EnabledMarks != nil {
 		value := pie.Map(v.EnabledMarks, func(t types.String) string {
 			return t.ValueString()
 		})
@@ -155,7 +155,7 @@ func (v Validation) Draft() (*sdk.FieldValidation, error) {
 		return base, nil
 	}
 
-	if len(v.EnabledNodeTypes) > 0 {
+	if v.EnabledNodeTypes != nil {
 		value := pie.Map(v.EnabledNodeTypes, func(t types.String) string {
 			return t.ValueString()
 		})

--- a/internal/resources/contenttype/model_test.go
+++ b/internal/resources/contenttype/model_test.go
@@ -1,0 +1,45 @@
+package contenttype
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationDraftReturnsErrorForUnsupportedValidation(t *testing.T) {
+	validation := Validation{}
+
+	_, err := validation.Draft()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported validation used")
+}
+
+func TestValidationDraftReturnsCorrectUniqueValidation(t *testing.T) {
+	validation := Validation{
+		Unique:  types.BoolValue(true),
+		Message: types.StringValue("Unique validation message"),
+	}
+
+	result, err := validation.Draft()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, true, *result.Unique)
+	assert.Equal(t, "Unique validation message", *result.Message)
+}
+
+func TestValidationDraftReturnsCorrectEnabledNodeTypesValidation(t *testing.T) {
+	validation := Validation{
+		EnabledNodeTypes: []types.String{},
+		Message:          types.StringValue("Unique validation message"),
+	}
+
+	result, err := validation.Draft()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, []string{}, *result.EnabledNodeTypes)
+	assert.Equal(t, "Unique validation message", *result.Message)
+}


### PR DESCRIPTION
This pull request addresses a bug in content type validation and enhances the robustness of the `Validation` struct by refining its handling of nil slices. Additionally, it introduces comprehensive unit tests to ensure correctness and prevent regressions.

### Bug Fixes:

* [`.changes/unreleased/Fixed-20250613-100705.yaml`](diffhunk://#diff-879e408a8a030fb48f86309a9a8f0b77d783c5467074a1a36616fd97bb512bcdR1-R3): Added a changelog entry documenting the fix for content type validation misinterpreting nil slices as empty slices.

### Code Improvements:

* [`internal/resources/contenttype/model.go`](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL126-R158): Updated the `Draft` method in the `Validation` struct to check for `nil` slices instead of using `len()` checks, ensuring proper handling of uninitialized slices.

### Testing Enhancements:

* [`internal/resources/contenttype/model_test.go`](diffhunk://#diff-faddce8b801d24695a07432d4fe12f3a2f65d2eb19770fe6f1a50c459a5d2764R1-R45): Added unit tests for the `Draft` method to verify behavior for unsupported validations, unique validations, and `EnabledNodeTypes` validations, ensuring comprehensive coverage.