### PR TITLE
fix: add validation to prevent creation of existing content types

### DIFF
--- a/.changes/unreleased/Fixed-20250613-103125.yaml
+++ b/.changes/unreleased/Fixed-20250613-103125.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added contenttype check for existing resources when creating
+time: 2025-06-13T10:31:25.216356419+02:00


### PR DESCRIPTION
This pull request introduces a fix to the `contentTypeResource` creation and import logic, ensuring proper validation and error handling for existing resources. The changes include adding checks for pre-existing content types during creation and improving error reporting during state import.

### Content Type Creation Enhancements:
* Added a check to verify whether a content type with the given ID already exists before attempting to create it. If found, an error is raised instructing the user to import or remove the resource before retrying. (`internal/resources/contenttype/resource.go`, [internal/resources/contenttype/resource.goR287-R303](diffhunk://#diff-b5fb2ac2141f05152af6d0968255603f89588ef617b90f83906343497a839ad9R287-R303))
* Simplified the `UpdateContentTypeWithResponse` method by removing unused parameters (`params`) in both ID-based and name-based creation flows. (`internal/resources/contenttype/resource.go`, [[1]](diffhunk://#diff-b5fb2ac2141f05152af6d0968255603f89588ef617b90f83906343497a839ad9R287-R303) [[2]](diffhunk://#diff-b5fb2ac2141f05152af6d0968255603f89588ef617b90f83906343497a839ad9L308-R315)

### State Import Improvements:
* Enhanced the `ImportState` method to handle errors during the `state.Import` process, ensuring unexpected issues are reported clearly to the user. (`internal/resources/contenttype/resource.go`, [internal/resources/contenttype/resource.goL565-R576](diffhunk://#diff-b5fb2ac2141f05152af6d0968255603f89588ef617b90f83906343497a839ad9L565-R576))

### Miscellaneous:
* Removed an unused import statement from `internal/resources/contenttype/resource.go`. (`internal/resources/contenttype/resource.go`, [internal/resources/contenttype/resource.goL26](diffhunk://#diff-b5fb2ac2141f05152af6d0968255603f89588ef617b90f83906343497a839ad9L26))
* Added a changelog entry documenting the fix in `.changes/unreleased/Fixed-20250613-103125.yaml`. (`.changes/unreleased/Fixed-20250613-103125.yaml`, [.changes/unreleased/Fixed-20250613-103125.yamlR1-R3](diffhunk://#diff-56ce248ee52a65bc948518838d4b3da918cee41bd065c4a93998ebb262873025R1-R3))