### PR TITLE
feat: Added editors as option to editor_interface resource

### DIFF
--- a/.changes/unreleased/Added-20250711-163430.yaml
+++ b/.changes/unreleased/Added-20250711-163430.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added editors as option to editor_interface resource
+time: 2025-07-11T16:34:30.488948503+02:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,6 +4,7 @@ dotenv: [ '.env' ]
 
 tasks:
   default:
+    silent: true
     cmd: task --list-all
 
   format:
@@ -36,6 +37,11 @@ tasks:
       VERSION: 99.0.0
       PLATFORM:
         sh: echo "$(go env GOOS)_$(go env GOARCH)"
+
+  build:
+    env:
+      GORELEASER_CURRENT_TAG: "v0.0.0"
+    cmd: goreleaser build --snapshot --clean --single-target --output terraform-provider-contentful
 
   coverage:
     cmds:

--- a/docs/resources/editor_interface.md
+++ b/docs/resources/editor_interface.md
@@ -24,6 +24,7 @@ Contentful Editor Interface customizes the appearance and behavior of field edit
 
 ### Optional
 
+- `editors` (Attributes List) You can add or replace the default entry editor with a custom editor (App or UI Extension) by configuring the optional editors property, which allows passing instance parameters and disabling the default editor if desired. (see [below for nested schema](#nestedatt--editors))
 - `sidebar` (Attributes List) (see [below for nested schema](#nestedatt--sidebar))
 
 ### Read-Only
@@ -58,6 +59,20 @@ Optional:
 - `tracking_field_id` (String)
 - `true_label` (String)
 
+
+
+<a id="nestedatt--editors"></a>
+### Nested Schema for `editors`
+
+Required:
+
+- `widget_id` (String)
+- `widget_namespace` (String)
+
+Optional:
+
+- `disabled` (Boolean)
+- `settings` (String)
 
 
 <a id="nestedatt--sidebar"></a>

--- a/examples/resources/contentful_contenttype/resource.tf
+++ b/examples/resources/contentful_contenttype/resource.tf
@@ -90,26 +90,3 @@ resource "contentful_contenttype" "example_contenttype" {
     }
   ]
 }
-
-resource "contentful_editor_interface" "example_editor_interface" {
-  space_id     = "space-id"
-  environment  = "master"
-  content_type = contentful_contenttype.example_contenttype.id
-  controls = [
-    {
-      field_id         = "asset_field"
-      widget_id        = "entryLinkEditor"
-      widget_namespace = "builtin"
-    },
-    {
-      field_id         = "entry_link_field"
-      widget_id        = "entryLinkEditor"
-      widget_namespace = "builtin"
-      settings = {
-        show_linked_entries = true
-        show_linked_assets  = false
-      }
-    }
-  ]
-}
-

--- a/examples/resources/contentful_editor_interface/resource.tf
+++ b/examples/resources/contentful_editor_interface/resource.tf
@@ -1,0 +1,72 @@
+resource "contentful_contenttype" "example_contenttype" {
+  space_id      =  "space-id"
+  environment   = "master"
+  id            = "example_contenttype"
+  name          = "name"
+  description   = "content type description"
+  display_field = "name"
+
+  fields = [
+    {
+      id   = "name"
+      name = "Name"
+      type = "Text"
+      required = true
+    },
+    {
+      id   = "content"
+      name = "Content"
+      type = "RichText"
+      required = false
+    },
+    {
+      id   = "tags"
+      name = "Tags"
+      type = "Array"
+      items = {
+        type = "Symbol"
+      }
+      required = false
+    }
+  ]
+}
+
+resource "contentful_editor_interface" "example_editor_interface" {
+  space_id      =  "space-id"
+  environment   = "master"
+  content_type = contentful_contenttype.example_contenttype.id
+  controls = [
+    {
+      field_id         = "name"
+      widget_id        = "singleLine"
+      widget_namespace = "builtin"
+    },
+    {
+      field_id         = "content"
+      widget_id        = "richTextEditor"
+      widget_namespace = "builtin"
+    },
+    {
+      field_id         = "tags"
+      widget_id        = "listInput"
+      widget_namespace = "builtin"
+    }
+  ]
+  sidebar = [
+    {
+      widget_id        = "content-preview-widget"
+      widget_namespace = "sidebar-builtin"
+    },
+    {
+      widget_id        = "translation-widget"
+      widget_namespace = "sidebar-builtin"
+    }
+  ]
+  editors = [
+    {
+      widget_namespace = "editor-builtin",
+      widget_id = "default-editor",
+      disabled = true
+    }
+  ]
+}

--- a/internal/resources/api_key/test_resources/update.tf
+++ b/internal/resources/api_key/test_resources/update.tf
@@ -1,6 +1,6 @@
 resource "contentful_apikey" "myapikey" {
-  space_id      = "{{ .spaceId }}"
+  space_id = "{{ .spaceId }}"
 
-  name = "{{ .name }}-updated"
+  name        = "{{ .name }}-updated"
   description = "{{ .description }}-updated"
 }

--- a/internal/resources/contenttype/resource.go
+++ b/internal/resources/contenttype/resource.go
@@ -668,7 +668,7 @@ func (e *contentTypeResource) ImportState(ctx context.Context, request resource.
 	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
 		response.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: localeId:env:spaceId. Got: %q", request.ID),
+			fmt.Sprintf("Expected import identifier with format: contentTypeId:env:spaceId. Got: %q", request.ID),
 		)
 		return
 	}

--- a/internal/resources/contenttype/resource_test.go
+++ b/internal/resources/contenttype/resource_test.go
@@ -415,7 +415,3 @@ func testContentTypeLinkConfig(identifier string, spaceId string, linkIdentifier
 		"spaceId":        spaceId,
 	})
 }
-
-func toPointer[T string | bool](value T) *T {
-	return &value
-}

--- a/internal/resources/editor_interface/resource.go
+++ b/internal/resources/editor_interface/resource.go
@@ -184,6 +184,37 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 					},
 				},
 			},
+			"editors": schema.ListNestedAttribute{
+				Optional: true,
+				Description: "You can add or replace the default entry editor with a custom editor (App or UI " +
+					"Extension) by configuring the optional editors property, which allows passing instance " +
+					"parameters and disabling the default editor if desired.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"disabled": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								custommodifier.BoolDefault(false),
+							},
+						},
+						"widget_id": schema.StringAttribute{
+							Required: true,
+						},
+						"widget_namespace": schema.StringAttribute{
+							Required: true,
+						},
+						"settings": schema.StringAttribute{
+							CustomType: jsontypes.NormalizedType{},
+							Optional:   true,
+							Computed:   true,
+							PlanModifiers: []planmodifier.String{
+								custommodifier.StringDefault("{}"),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/internal/resources/editor_interface/resource_test.go
+++ b/internal/resources/editor_interface/resource_test.go
@@ -63,6 +63,11 @@ func TestAccEditorInterfaceResource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "controls.1.field_id", "description"),
 					resource.TestCheckResourceAttr(resourceName, "controls.1.widget_id", "richTextEditor"),
 					resource.TestCheckResourceAttr(resourceName, "controls.1.settings.help_text", "Rich text content"),
+					resource.TestCheckResourceAttr(resourceName, "sidebar.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "sidebar.0.widget_id", "content-preview-widget"),
+					resource.TestCheckResourceAttr(resourceName, "sidebar.1.widget_id", "translation-widget"),
+					resource.TestCheckResourceAttr(resourceName, "editors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "editors.0.widget_id", "default-editor"),
 				),
 			},
 			// Test import
@@ -247,6 +252,25 @@ resource "contentful_editor_interface" "test_editor_interface" {
       settings = {
         help_text = "Rich text content"
       }
+    }
+  ]
+	
+	sidebar = [
+    {
+      widget_id        = "content-preview-widget"
+      widget_namespace = "sidebar-builtin"
+    },
+    {
+      widget_id        = "translation-widget"
+      widget_namespace = "sidebar-builtin"
+    }
+  ]
+	
+	  editors = [
+    {
+      widget_namespace = "editor-builtin",
+      widget_id = "default-editor",
+      disabled = true
     }
   ]
 }

--- a/internal/sdk/main.gen.go
+++ b/internal/sdk/main.gen.go
@@ -105,11 +105,18 @@ const (
 	EditorInterfaceControlWidgetNamespaceExtension EditorInterfaceControlWidgetNamespace = "extension"
 )
 
+// Defines values for EditorInterfaceEditorWidgetNamespace.
+const (
+	EditorInterfaceEditorWidgetNamespaceApp       EditorInterfaceEditorWidgetNamespace = "app"
+	EditorInterfaceEditorWidgetNamespaceBuiltin   EditorInterfaceEditorWidgetNamespace = "builtin"
+	EditorInterfaceEditorWidgetNamespaceExtension EditorInterfaceEditorWidgetNamespace = "extension"
+)
+
 // Defines values for EditorInterfaceSidebarItemWidgetNamespace.
 const (
-	EditorInterfaceSidebarItemWidgetNamespaceApp       EditorInterfaceSidebarItemWidgetNamespace = "app"
-	EditorInterfaceSidebarItemWidgetNamespaceBuiltin   EditorInterfaceSidebarItemWidgetNamespace = "builtin"
-	EditorInterfaceSidebarItemWidgetNamespaceExtension EditorInterfaceSidebarItemWidgetNamespace = "extension"
+	App       EditorInterfaceSidebarItemWidgetNamespace = "app"
+	Builtin   EditorInterfaceSidebarItemWidgetNamespace = "builtin"
+	Extension EditorInterfaceSidebarItemWidgetNamespace = "extension"
 )
 
 // Defines values for EntryCollectionSysType.
@@ -604,6 +611,7 @@ type EditorInterface struct {
 
 	// EditorLayout To be implemented
 	EditorLayout *[]map[string]interface{} `json:"editorLayout,omitempty"`
+	Editors      *[]EditorInterfaceEditor  `json:"editors,omitempty"`
 
 	// GroupControls To be implemented
 	GroupControls *[]map[string]interface{}     `json:"groupControls,omitempty"`
@@ -631,6 +639,24 @@ type EditorInterfaceControl struct {
 
 // EditorInterfaceControlWidgetNamespace Namespace of the widget (optional)
 type EditorInterfaceControlWidgetNamespace string
+
+// EditorInterfaceEditor defines model for EditorInterfaceEditor.
+type EditorInterfaceEditor struct {
+	// Disabled Whether the field is disabled
+	Disabled *bool `json:"disabled,omitempty"`
+
+	// Settings Widget-specific settings (optional)
+	Settings *EditorInterfaceSettings `json:"settings,omitempty"`
+
+	// WidgetId ID of the widget to use for this field (optional)
+	WidgetId *string `json:"widgetId,omitempty"`
+
+	// WidgetNamespace Namespace of the widget (optional)
+	WidgetNamespace *EditorInterfaceEditorWidgetNamespace `json:"widgetNamespace,omitempty"`
+}
+
+// EditorInterfaceEditorWidgetNamespace Namespace of the widget (optional)
+type EditorInterfaceEditorWidgetNamespace string
 
 // EditorInterfaceSettings Widget-specific settings (optional)
 type EditorInterfaceSettings struct {
@@ -683,6 +709,7 @@ type EditorInterfaceUpdate struct {
 
 	// EditorLayout To be implemented
 	EditorLayout *[]map[string]interface{} `json:"editorLayout,omitempty"`
+	Editors      *[]EditorInterfaceEditor  `json:"editors,omitempty"`
 
 	// GroupControls To be implemented
 	GroupControls *[]map[string]interface{}     `json:"groupControls,omitempty"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2794,6 +2794,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EditorInterfaceSidebarItem'
+        editors:
+          type: array
+          items:
+            $ref: '#/components/schemas/EditorInterfaceEditor'
         editorLayout:
           type: array
           description: To be implemented
@@ -2822,6 +2826,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EditorInterfaceSidebarItem'
+        editors:
+          type: array
+          items:
+            $ref: '#/components/schemas/EditorInterfaceEditor'
         editorLayout:
           type: array
           description: To be implemented
@@ -2873,8 +2881,22 @@ components:
           description: Whether the field is disabled
         settings:
           $ref: '#/components/schemas/EditorInterfaceSettings'
-      required:
-        - fieldId
+
+    EditorInterfaceEditor:
+      type: object
+      properties:
+        widgetId:
+          type: string
+          description: ID of the widget to use for this field (optional)
+        widgetNamespace:
+          type: string
+          description: Namespace of the widget (optional)
+          enum: [ builtin, app, extension ]
+        disabled:
+          type: boolean
+          description: Whether the field is disabled
+        settings:
+          $ref: '#/components/schemas/EditorInterfaceSettings'
 
     EditorInterfaceSettings:
       type: object


### PR DESCRIPTION
This pull request introduces significant changes to the Contentful Editor Interface functionality, including support for custom editors, updates to the schema and SDK, and improvements to the example configurations and documentation. The changes aim to enhance flexibility and usability by allowing custom editors to be configured alongside existing controls and sidebars.

### Contentful Editor Interface Enhancements:
* **Support for Custom Editors**: Added the `editors` property to the Editor Interface resource, allowing users to configure custom entry editors with optional settings and the ability to disable the default editor. This includes updates to the schema (`internal/resources/editor_interface/resource.go`) and the SDK (`internal/sdk/main.gen.go`). [[1]](diffhunk://#diff-081d8d2047af5174cf857776b5c000c9adfbc9cb54272fd0f3d41207ed277831R25) [[2]](diffhunk://#diff-32962931dd0647856ceec8de81ad55ff5df5eac381ef9c1e88cbf9425c76d987R187-R217) [[3]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336R614)
* **Nested Schema for Editors**: Defined a nested schema for `editors` in the documentation, detailing required attributes like `widget_id` and `widget_namespace` and optional attributes like `disabled` and `settings`.
* **OpenAPI Specification Update**: Updated the OpenAPI specification to include the `editors` property and its schema definition. [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39R2797-R2800) [[2]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L2876-R2899)

### Example Configuration Updates:
* **Expanded Example Resources**: Updated example configurations to showcase the usage of the new `editors` property, including custom widgets and settings. [[1]](diffhunk://#diff-90f52b0c433c1867d40524e60ae79597c4629d66a78c87c6f49a91832075f990R1-R72) [[2]](diffhunk://#diff-ed458766fa0aa5d16c9862f8b9ff3f51fc97391e0b68262a42e3260a98c3e19dR256-R274)

### Documentation Improvements:
* **Editor Interface Documentation**: Enhanced the documentation for the Editor Interface resource, explaining the new `editors` property and its nested schema.

### Codebase Simplifications:
* **Refactoring and Cleanup**: Removed unused methods and renamed files for better clarity, such as renaming `models.go` to `model.go` in the Editor Interface resource. [[1]](diffhunk://#diff-081d8d2047af5174cf857776b5c000c9adfbc9cb54272fd0f3d41207ed277831L6) [[2]](diffhunk://#diff-081d8d2047af5174cf857776b5c000c9adfbc9cb54272fd0f3d41207ed277831L198-L285)
* **Updated Import Identifier Error Message**: Improved error messaging for the Content Type resource import functionality.

These changes collectively improve the flexibility and usability of the Contentful Editor Interface resource while enhancing the overall codebase and documentation.