### PR TITLE
fix: import of content type where a field has range validation

### DIFF
--- a/internal/resources/contenttype/model.go
+++ b/internal/resources/contenttype/model.go
@@ -955,7 +955,7 @@ func getValidation(cfVal sdk.FieldValidation) (*Validation, error) {
 
 	if cfVal.AssetFileSize != nil {
 		return &Validation{
-			Range: &Size{
+			AssetFileSize: &Size{
 				Max: types.Float64PointerValue(cfVal.AssetFileSize.Max),
 				Min: types.Float64PointerValue(cfVal.AssetFileSize.Min),
 			},

--- a/internal/resources/contenttype/model.go
+++ b/internal/resources/contenttype/model.go
@@ -963,6 +963,16 @@ func getValidation(cfVal sdk.FieldValidation) (*Validation, error) {
 		}, nil
 	}
 
+	if cfVal.Range != nil {
+		return &Validation{
+			Range: &Size{
+				Max: types.Float64PointerValue(cfVal.Range.Max),
+				Min: types.Float64PointerValue(cfVal.Range.Min),
+			},
+			Message: types.StringPointerValue(cfVal.Message),
+		}, nil
+	}
+
 	if cfVal.Regexp != nil {
 		return &Validation{
 			Regexp: &Regexp{

--- a/internal/resources/contenttype/model.go
+++ b/internal/resources/contenttype/model.go
@@ -1027,16 +1027,6 @@ func getValidation(cfVal sdk.FieldValidation) (*Validation, error) {
 		}, nil
 	}
 
-	if cfVal.AssetFileSize != nil {
-		return &Validation{
-			AssetFileSize: &Size{
-				Max: types.Float64PointerValue(cfVal.AssetFileSize.Max),
-				Min: types.Float64PointerValue(cfVal.AssetFileSize.Min),
-			},
-			Message: types.StringPointerValue(cfVal.Message),
-		}, nil
-	}
-
 	if cfVal.Unique != nil {
 		return &Validation{
 			Unique:  types.BoolPointerValue(cfVal.Unique),


### PR DESCRIPTION
Previously, when importing a content type where a field contained a range validation on a number it failed. This seems to just be a missed if statement that returns the correct validation. I tested it locally and it works. The issue is described [here](https://github.com/labd/terraform-provider-contentful/issues/90).

In addition I found a duplicated if statement that I removed.