### PR TITLE
fix: contenttype display_field is now optional to match contentful

### DIFF
--- a/internal/resources/contenttype/resource.go
+++ b/internal/resources/contenttype/resource.go
@@ -275,7 +275,7 @@ func (e *contentTypeResource) Schema(ctx context.Context, request resource.Schem
 				Required: true,
 			},
 			"display_field": schema.StringAttribute{
-				Required: true,
+				Optional: true,
 			},
 			"description": schema.StringAttribute{
 				Optional: true,


### PR DESCRIPTION
Contentful does not require display_field in content types. Therefore this change has been made to remove that constraint from the provider.

I tested running terraform apply with the provider locally and it worked fine. 

This PR is for [this](https://github.com/labd/terraform-provider-contentful/issues/96) issue