### PR TITLE
fix: update content type display_field to be optional and handle empty values

### DIFF
--- a/.changes/unreleased/Fixed-20250801-153756.yaml
+++ b/.changes/unreleased/Fixed-20250801-153756.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix setting contenttype.display_field to empty breaking apply
+time: 2025-08-01T15:37:56.133801091+02:00

--- a/docs/resources/contenttype.md
+++ b/docs/resources/contenttype.md
@@ -112,7 +112,6 @@ resource "contentful_contenttype" "example_contenttype" {
 
 ### Required
 
-- `display_field` (String)
 - `environment` (String)
 - `fields` (Attributes List) (see [below for nested schema](#nestedatt--fields))
 - `name` (String)
@@ -121,6 +120,7 @@ resource "contentful_contenttype" "example_contenttype" {
 ### Optional
 
 - `description` (String)
+- `display_field` (String)
 - `id` (String) content type id
 
 ### Read-Only

--- a/internal/resources/contenttype/model.go
+++ b/internal/resources/contenttype/model.go
@@ -827,7 +827,7 @@ func (c *ContentType) Create() (*sdk.ContentTypeCreate, error) {
 
 	contentfulType := &sdk.ContentTypeCreate{
 		Name:         c.Name.ValueString(),
-		DisplayField: c.DisplayField.ValueString(),
+		DisplayField: c.DisplayField.ValueStringPointer(),
 		Fields:       fields,
 	}
 
@@ -853,7 +853,7 @@ func (c *ContentType) Update() (*sdk.ContentTypeUpdate, error) {
 
 	contentfulType := &sdk.ContentTypeUpdate{
 		Name:         c.Name.ValueString(),
-		DisplayField: c.DisplayField.ValueString(),
+		DisplayField: c.DisplayField.ValueStringPointer(),
 		Fields:       fields,
 	}
 
@@ -871,7 +871,7 @@ func (c *ContentType) Import(n *sdk.ContentType) error {
 	c.Description = types.StringPointerValue(n.Description)
 
 	c.Name = types.StringValue(n.Name)
-	c.DisplayField = types.StringValue(n.DisplayField)
+	c.DisplayField = types.StringPointerValue(n.DisplayField)
 
 	var fields []Field
 
@@ -900,7 +900,7 @@ func (c *ContentType) Equal(n *sdk.ContentType) bool {
 		return false
 	}
 
-	if c.DisplayField.ValueString() != n.DisplayField {
+	if c.DisplayField.ValueStringPointer() != n.DisplayField {
 		return false
 	}
 

--- a/internal/resources/contenttype/resource_test.go
+++ b/internal/resources/contenttype/resource_test.go
@@ -43,7 +43,7 @@ func TestContentTypeResource_Create(t *testing.T) {
 						assert.Equal(t, int64(2), contentType.Sys.Version)
 						assert.EqualValues(t, "tf_test1", contentType.Sys.Id)
 						assert.EqualValues(t, "none", *contentType.Description)
-						assert.EqualValues(t, "field1", contentType.DisplayField)
+						assert.EqualValues(t, "field1", *contentType.DisplayField)
 						assert.Len(t, contentType.Fields, 3)
 						assert.Equal(t, sdk.Field{
 							Id:           "field1",
@@ -105,7 +105,7 @@ func TestContentTypeResource_Create(t *testing.T) {
 						assert.Equal(t, int64(6), contentType.Sys.Version)
 						assert.EqualValues(t, "tf_test1", contentType.Sys.Id)
 						assert.EqualValues(t, "Terraform Acc Test Content Type description change", *contentType.Description)
-						assert.EqualValues(t, "field1", contentType.DisplayField)
+						assert.EqualValues(t, "field1", *contentType.DisplayField)
 						assert.Len(t, contentType.Fields, 2)
 						assert.Equal(t, sdk.Field{
 							Id:          "field1",
@@ -142,7 +142,7 @@ func TestContentTypeResource_Create(t *testing.T) {
 						assert.Equal(t, int64(8), contentType.Sys.Version)
 						assert.EqualValues(t, "tf_test1", contentType.Sys.Id)
 						assert.EqualValues(t, "Terraform Acc Test Content Type description change", *contentType.Description)
-						assert.EqualValues(t, "field1", contentType.DisplayField)
+						assert.EqualValues(t, "field1", *contentType.DisplayField)
 						assert.Len(t, contentType.Fields, 2)
 						assert.Equal(t, sdk.Field{
 							Id:          "field1",
@@ -178,7 +178,7 @@ func TestContentTypeResource_Create(t *testing.T) {
 						assert.Equal(t, int64(2), contentType.Sys.Version)
 						assert.EqualValues(t, "tf_linked", contentType.Sys.Id)
 						assert.EqualValues(t, "Terraform Acc Test Content Type with links", *contentType.Description)
-						assert.EqualValues(t, "asset_field", contentType.DisplayField)
+						assert.EqualValues(t, "asset_field", *contentType.DisplayField)
 						assert.Len(t, contentType.Fields, 2)
 
 						expectedItems := sdk.FieldItemLink{
@@ -229,7 +229,7 @@ func TestContentTypeResource_Create(t *testing.T) {
 						assert.Equal(t, int64(2), contentType.Sys.Version)
 						assert.EqualValues(t, "tf_test2", contentType.Sys.Id)
 						assert.EqualValues(t, "Terraform Acc Test Content Type description change", *contentType.Description)
-						assert.EqualValues(t, "field1", contentType.DisplayField)
+						assert.EqualValues(t, "field1", *contentType.DisplayField)
 						assert.Len(t, contentType.Fields, 3)
 						assert.Equal(t, sdk.Field{
 							Id:           "field1",

--- a/internal/sdk/main.gen.go
+++ b/internal/sdk/main.gen.go
@@ -562,7 +562,7 @@ type ContentType struct {
 	Description *string `json:"description,omitempty"`
 
 	// DisplayField ID of the field to use as the display field
-	DisplayField string  `json:"displayField"`
+	DisplayField *string `json:"displayField,omitempty"`
 	Fields       []Field `json:"fields"`
 
 	// Name Name of the content type
@@ -596,7 +596,7 @@ type ContentTypeCreate struct {
 	Description *string `json:"description,omitempty"`
 
 	// DisplayField ID of the field to use as the display field
-	DisplayField string  `json:"displayField"`
+	DisplayField *string `json:"displayField,omitempty"`
 	Fields       []Field `json:"fields"`
 
 	// Name Name of the content type
@@ -609,7 +609,7 @@ type ContentTypeUpdate struct {
 	Description *string `json:"description,omitempty"`
 
 	// DisplayField ID of the field to use as the display field
-	DisplayField string  `json:"displayField"`
+	DisplayField *string `json:"displayField,omitempty"`
 	Fields       []Field `json:"fields"`
 
 	// Name Name of the content type

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1609,7 +1609,6 @@ components:
           $ref: '#/components/schemas/SystemPropertiesResource'
       required:
         - name
-        - displayField
         - fields
         - sys
 
@@ -1660,7 +1659,6 @@ components:
           type: string
       required:
         - name
-        - displayField
         - fields
 
     ContentTypeUpdate:
@@ -1681,7 +1679,6 @@ components:
           type: string
       required:
         - name
-        - displayField
         - fields
 
 


### PR DESCRIPTION
This pull request addresses a bug where setting `contenttype.display_field` to empty caused issues during the apply phase. The changes ensure that `display_field` is now optional across the codebase and properly handles empty values. The key updates include modifications to the SDK models, resource logic, and documentation.

### Bug Fixes and Functional Updates:
* [`.changes/unreleased/Fixed-20250801-153756.yaml`](diffhunk://#diff-59f670f4fa770c1945c6451d93ac7ac100bbc01a863cd488b56824b4b2cd78a2R1-R3): Added a changelog entry to document the fix for the `contenttype.display_field` issue.
* [`internal/resources/contenttype/model.go`](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL830-R830): Updated the `Create`, `Update`, `Import`, and `Equal` methods to use `ValueStringPointer()` for `DisplayField`, ensuring proper handling of `nil` values. [[1]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL830-R830) [[2]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL856-R856) [[3]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL874-R874) [[4]](diffhunk://#diff-4811283b8c0cc56cc648930122b2d04ff7edac172b45b0369814e3ad9de677eaL903-R903)

### SDK Model Adjustments:
* [`internal/sdk/main.gen.go`](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L565-R565): Changed the `DisplayField` field in `ContentType`, `ContentTypeCreate`, and `ContentTypeUpdate` structs from `string` to `*string` to make it optional. [[1]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L565-R565) [[2]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L599-R599) [[3]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L612-R612)

### OpenAPI Specification Updates:
* [`openapi.yaml`](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L1612): Removed `displayField` from the list of required fields for `ContentType`, `ContentTypeCreate`, and `ContentTypeUpdate` components. [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L1612) [[2]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L1663) [[3]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L1684)

### Documentation Updates:
* [`docs/resources/contenttype.md`](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0L115): Moved `display_field` from the "Required" to the "Optional" section to reflect its new status. [[1]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0L115) [[2]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0R123)