### PR TITLE
fix: handle empty description for preview environment resource

### DIFF
--- a/.changes/unreleased/Fixed-20250801-152422.yaml
+++ b/.changes/unreleased/Fixed-20250801-152422.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed error thrown when no description is provided for preview environment resource
+time: 2025-08-01T15:24:22.052061489+02:00

--- a/docs/resources/contenttype.md
+++ b/docs/resources/contenttype.md
@@ -112,7 +112,6 @@ resource "contentful_contenttype" "example_contenttype" {
 
 ### Required
 
-- `display_field` (String)
 - `environment` (String)
 - `fields` (Attributes List) (see [below for nested schema](#nestedatt--fields))
 - `name` (String)
@@ -121,6 +120,7 @@ resource "contentful_contenttype" "example_contenttype" {
 ### Optional
 
 - `description` (String)
+- `display_field` (String)
 - `id` (String) content type id
 
 ### Read-Only

--- a/internal/resources/preview_environment/model.go
+++ b/internal/resources/preview_environment/model.go
@@ -28,11 +28,13 @@ func (p *PreviewEnvironment) Import(env *sdk.PreviewEnvironment) {
 	p.ID = types.StringValue(env.Sys.Id)
 	p.SpaceID = types.StringValue(env.Sys.Space.Sys.Id)
 	p.Name = types.StringValue(env.Name)
-	p.Version = types.Int64Value(int64(*env.Sys.Version))
-	p.Description = types.StringValue(env.Description)
+	p.Version = types.Int64PointerValue(env.Sys.Version)
+	if env.Description != nil && *env.Description != "" {
+		p.Description = types.StringPointerValue(env.Description)
+	}
 
 	// Map configurations
-	configurations := []Configuration{}
+	var configurations []Configuration
 	for _, config := range env.Configurations {
 		configurations = append(configurations, Configuration{
 			ContentType: types.StringValue(config.ContentType),
@@ -50,7 +52,7 @@ func (p *PreviewEnvironment) Draft() *sdk.PreviewEnvironmentInput {
 	}
 
 	if !p.Description.IsNull() && !p.Description.IsUnknown() {
-		description := p.Description.ValueString()
+		description := p.Description.ValueStringPointer()
 		draft.Description = description
 	}
 

--- a/internal/resources/preview_environment/resource_test.go
+++ b/internal/resources/preview_environment/resource_test.go
@@ -1,0 +1,203 @@
+package preview_environment_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/labd/terraform-provider-contentful/internal/acctest"
+	"github.com/labd/terraform-provider-contentful/internal/provider"
+	"github.com/labd/terraform-provider-contentful/internal/sdk"
+	"github.com/labd/terraform-provider-contentful/internal/utils"
+)
+
+func TestAccPreviewEnvironmentResource_Basic(t *testing.T) {
+	spaceID := os.Getenv("CONTENTFUL_SPACE_ID")
+	resourceName := "contentful_preview_environment.preview_environment"
+
+	var previewEnvironment sdk.PreviewEnvironment
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheck(t)
+			acctest.TestHasNoContentTypes(t)
+		},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"contentful": providerserver.NewProtocol6WithError(provider.New("test", false)()),
+		},
+		CheckDestroy: testAccCheckContentfulPreviewEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			// Create and test initial setup
+			{
+				Config: testAccPreviewEnvironmentConfig(spaceID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPreviewEnvironmentExists(resourceName, &previewEnvironment),
+					resource.TestCheckResourceAttr(resourceName, "space_id", spaceID),
+					resource.TestCheckNoResourceAttr(resourceName, "description"),
+				),
+			},
+			// Test updates
+			{
+				Config: testAccEditorInterfaceConfigUpdate(spaceID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPreviewEnvironmentExists(resourceName, &previewEnvironment),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is a test preview environment"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					return fmt.Sprintf(
+						"%s:%s",
+						rs.Primary.ID,
+						rs.Primary.Attributes["space_id"],
+					), nil
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckPreviewEnvironmentExists(n string, previewEnvironment *sdk.PreviewEnvironment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		spaceID := rs.Primary.Attributes["space_id"]
+
+		client := acctest.GetClient()
+		resp, err := client.GetPreviewEnvironmentWithResponse(
+			context.Background(),
+			spaceID,
+			rs.Primary.ID,
+		)
+
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode() != 200 {
+			return fmt.Errorf("error getting editor interface: %d", resp.StatusCode())
+		}
+
+		*previewEnvironment = *resp.JSON200
+		return nil
+	}
+}
+
+func testAccCheckContentfulPreviewEnvironmentDestroy(s *terraform.State) error {
+	client := acctest.GetClient()
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "contentful_contenttype" {
+			spaceID := rs.Primary.Attributes["space_id"]
+			environment := rs.Primary.Attributes["environment"]
+
+			resp, err := client.GetContentTypeWithResponse(ctx, spaceID, environment, rs.Primary.ID)
+			if err := utils.CheckClientResponse(resp, err, http.StatusNotFound); err != nil {
+				return fmt.Errorf("error checking content type exists: %w", err)
+			}
+		}
+
+		if rs.Type == "contentful_preview_environment" {
+			spaceID := rs.Primary.Attributes["space_id"]
+
+			resp, err := client.GetPreviewEnvironmentWithResponse(ctx, spaceID, rs.Primary.ID)
+			if err := utils.CheckClientResponse(resp, err, http.StatusNotFound); err != nil {
+				return fmt.Errorf("error checking preview environment exists: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccPreviewEnvironmentConfig(spaceID string) string {
+	return fmt.Sprintf(`
+resource "contentful_contenttype" "example_contenttype" {
+  space_id      = "%s"
+  environment   = "master"
+  id            = "example_contenttype"
+  name          = "name"
+  description   = "content type description"
+  display_field = "name"
+
+  fields = [
+    {
+      id       = "name"
+      name     = "Name"
+      type     = "Text"
+      required = true
+    }
+  ]
+}
+	
+resource "contentful_preview_environment" "preview_environment" {
+  name     = "Test"
+  space_id = "%s"
+  configuration = [
+	{
+	  content_type = contentful_contenttype.example_contenttype.id
+      enabled      = true
+      url          = "http://www.example.com"
+	}
+  ]	
+}
+`, spaceID, spaceID)
+}
+
+func testAccEditorInterfaceConfigUpdate(spaceID string) string {
+	return fmt.Sprintf(`
+resource "contentful_contenttype" "example_contenttype" {
+  space_id      = "%s"
+  environment   = "master"
+  id            = "example_contenttype"
+  name          = "name"
+  description   = "content type description"
+  display_field = "name"
+
+  fields = [
+    {
+      id       = "name"
+      name     = "Name"
+      type     = "Text"
+      required = true
+    }
+  ]
+}	
+	
+resource "contentful_preview_environment" "preview_environment" {
+  name     = "Test"
+  space_id = "%s"
+  description = "This is a test preview environment"
+  configuration = [
+	{
+	  content_type = contentful_contenttype.example_contenttype.id
+      enabled      = true
+      url          = "http://www.example.com"
+	}
+  ]	
+}
+`, spaceID, spaceID)
+}

--- a/internal/sdk/main.gen.go
+++ b/internal/sdk/main.gen.go
@@ -1140,7 +1140,7 @@ type PreviewEnvironment struct {
 	Configurations []PreviewConfiguration `json:"configurations"`
 
 	// Description Description of the preview environment
-	Description string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// Name Name of the preview environment
 	Name string                             `json:"name"`
@@ -1153,7 +1153,7 @@ type PreviewEnvironmentInput struct {
 	Configurations []PreviewConfiguration `json:"configurations"`
 
 	// Description Description of the preview environment
-	Description string `json:"description"`
+	Description *string `json:"description,omitempty"`
 
 	// Name Name of the preview environment
 	Name string `json:"name"`

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3447,7 +3447,6 @@ components:
       required:
         - name
         - sys
-        - description
         - configurations
 
 
@@ -3468,7 +3467,6 @@ components:
 
       required:
         - name
-        - description
         - configurations
 
     Error:


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of `description` fields for preview environments, updates documentation, and enhances test coverage. The most significant updates include making the `description` field optional, fixing related errors, and adding an acceptance test for preview environments.

### Changes to the `description` field:

* Made the `description` field optional in the `PreviewEnvironment` and `PreviewEnvironmentInput` structs by changing its type to a pointer (`*string`) and adding the `omitempty` tag (`internal/sdk/main.gen.go`, [[1]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L1143-R1143) [[2]](diffhunk://#diff-29b5631321ae621e1f318adba3e1943e899be0a03499ef50b5f17c13ce7a1336L1156-R1156).
* Updated the OpenAPI specification to remove `description` from the list of required fields (`openapi.yaml`, [[1]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L3450) [[2]](diffhunk://#diff-d910ba2ef878f7db0223a966b81c8b3f3b65027bb39e4431bb05140171eece39L3471).
* Fixed an error in the `Import` method of the `PreviewEnvironment` model to handle cases where `description` is not provided (`internal/resources/preview_environment/model.go`, [internal/resources/preview_environment/model.goL31-R37](diffhunk://#diff-71b084b78c4fcd45795759c56bc241a48b9b884cff52d1aac42fb3001c2ce0c4L31-R37)).
* Updated the `Draft` method to use `ValueStringPointer` for the `description` field (`internal/resources/preview_environment/model.go`, [internal/resources/preview_environment/model.goL53-R55](diffhunk://#diff-71b084b78c4fcd45795759c56bc241a48b9b884cff52d1aac42fb3001c2ce0c4L53-R55)).

### Documentation updates:

* Moved the `display_field` property from the "Required" section to the "Optional" section in the `contenttype.md` resource documentation (`docs/resources/contenttype.md`, [[1]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0L115) [[2]](diffhunk://#diff-b82d6bc674f65a4190f0049a6ed75204b75bf677adf7d41c03a18f4a91a6dee0R123).

### Testing improvements:

* Added an acceptance test for the `contentful_preview_environment` resource, covering basic creation, updates, and import scenarios (`internal/resources/preview_environment/resource_test.go`, [internal/resources/preview_environment/resource_test.goR1-R203](diffhunk://#diff-32bbd3e92f0b69ac1e30a584a42f402d48d46e257f28a57e66e1301dfa76fdb5R1-R203)).

### Bug fix:

* Added a changelog entry documenting the fix for the error that occurred when no `description` was provided for a preview environment resource (`.changes/unreleased/Fixed-20250801-152422.yaml`, [.changes/unreleased/Fixed-20250801-152422.yamlR1-R3](diffhunk://#diff-6dc0c8c9ad08f88326e73a0fdd283cae4caf1c1816245d7872f62e4bbdd59b6cR1-R3)).