### PR TITLE
fix: allow for setting `all` as single value on role permission

### DIFF
--- a/.changes/unreleased/Fixed-20250912-151119.yaml
+++ b/.changes/unreleased/Fixed-20250912-151119.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Improved permission handling of role resource
+time: 2025-09-12T15:11:19.67326162+02:00

--- a/internal/resources/role/model_test.go
+++ b/internal/resources/role/model_test.go
@@ -1,0 +1,115 @@
+package role
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/iancoleman/orderedmap"
+	"github.com/labd/terraform-provider-contentful/internal/sdk"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRole_BuildPermissionsFromAPIResponse_Empty(t *testing.T) {
+	role := &Role{}
+	err := role.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: &orderedmap.OrderedMap{},
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, role.Permission)
+}
+
+func TestRole_BuildPermissionsFromAPIResponse_Error(t *testing.T) {
+	permissions := orderedmap.New()
+	permissions.Set("ContentModel", 1)
+
+	role := &Role{}
+	err := role.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: permissions,
+	})
+
+	assert.Error(t, err)
+}
+
+func TestRole_BuildPermissionsFromAPIResponse_ErrorSlice(t *testing.T) {
+	permissions := orderedmap.New()
+	permissions.Set("ContentModel", []interface{}{1, 2})
+
+	role := &Role{}
+	err := role.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: permissions,
+	})
+
+	assert.Error(t, err)
+}
+
+func TestRole_BuildPermissionsFromAPIResponse_All(t *testing.T) {
+	permissions := orderedmap.New()
+	permissions.Set("ContentModel", "all")
+
+	r := &Role{}
+	err := r.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: permissions,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(r.Permission))
+	assert.Equal(t, r.Permission, []Permission{
+		{
+			ID:     types.StringValue("ContentModel"),
+			Value:  types.StringValue("all"),
+			Values: nil,
+		},
+	})
+}
+
+func TestRole_BuildPermissionsFromAPIResponse_Values(t *testing.T) {
+	permissions := orderedmap.New()
+	permissions.Set("ContentModel", []string{"read"})
+
+	r := &Role{}
+	err := r.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: permissions,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(r.Permission))
+	assert.Equal(t, r.Permission, []Permission{
+		{
+			ID:    types.StringValue("ContentModel"),
+			Value: types.StringNull(),
+			Values: []basetypes.StringValue{
+				types.StringValue("read"),
+			},
+		},
+	})
+}
+
+func TestRole_BuildPermissionsFromAPIResponse_Combination(t *testing.T) {
+	permissions := orderedmap.New()
+	permissions.Set("ContentModel", []string{"read"})
+	permissions.Set("Settings", []string{})
+	permissions.Set("ContentDelivery", "all")
+
+	r := &Role{}
+	err := r.BuildPermissionsFromAPIResponse(&sdk.Role{
+		Permissions: permissions,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(r.Permission))
+	assert.Equal(t, r.Permission, []Permission{
+		{
+			ID:    types.StringValue("ContentModel"),
+			Value: types.StringNull(),
+			Values: []basetypes.StringValue{
+				types.StringValue("read"),
+			},
+		},
+		{
+			ID:     types.StringValue("ContentDelivery"),
+			Value:  types.StringValue("all"),
+			Values: nil,
+		},
+	})
+}

--- a/internal/resources/role/resource.go
+++ b/internal/resources/role/resource.go
@@ -159,7 +159,14 @@ func (e *roleResource) Create(ctx context.Context, request resource.CreateReques
 	}
 
 	state := &Role{}
-	state.Import(resp.JSON201)
+	err = state.Import(resp.JSON201)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error creating role",
+			"Could not parse response: "+err.Error(),
+		)
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
 }
@@ -182,7 +189,14 @@ func (e *roleResource) Read(ctx context.Context, request resource.ReadRequest, r
 		response.Diagnostics.AddError("Error reading role", err.Error())
 	}
 
-	state.Import(resp.JSON200)
+	err = state.Import(resp.JSON200)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error reading role",
+			"Could not parse response: "+err.Error(),
+		)
+		return
+	}
 
 	response.Diagnostics.Append(request.State.Set(ctx, &state)...)
 }
@@ -225,7 +239,14 @@ func (e *roleResource) Update(ctx context.Context, request resource.UpdateReques
 		return
 	}
 
-	state.Import(resp.JSON200)
+	err = state.Import(resp.JSON200)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error updating role",
+			"Could not parse response: "+err.Error(),
+		)
+		return
+	}
 
 	// Set state
 	response.Diagnostics.Append(response.State.Set(ctx, state)...)
@@ -258,7 +279,14 @@ func (e *roleResource) Delete(ctx context.Context, request resource.DeleteReques
 		return
 	}
 
-	state.Import(resp.JSON200)
+	err = state.Import(resp.JSON200)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error deleting role",
+			"Could not parse response: "+err.Error(),
+		)
+		return
+	}
 
 	// Create delete parameters with latest version
 	params := &sdk.DeleteRoleParams{
@@ -315,7 +343,14 @@ func (e *roleResource) ImportState(ctx context.Context, request resource.ImportS
 	}
 
 	role := Role{}
-	role.Import(resp.JSON200)
+	err = role.Import(resp.JSON200)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error importing role",
+			"Could not parse response: "+err.Error(),
+		)
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, role)...)
 }


### PR DESCRIPTION
This pull request improves the permission handling logic for the role resource by making permission parsing more robust and error-aware. The changes introduce proper error handling when importing roles and parsing permissions, ensuring that unexpected or malformed permission data is surfaced as errors instead of being silently ignored. Additionally, comprehensive unit tests have been added to verify the new behavior.

**Permission handling improvements:**

* Refactored the `BuildPermissionsFromAPIResponse` method in `model.go` to return errors for unexpected or invalid permission data types, instead of silently skipping them. Now, permission parsing is stricter and more reliable. [[1]](diffhunk://#diff-76b4955dbb1a185cbd0631d78538c22cddfd2333b5d8540d16d1d93de9bc7ddfL123-R134) [[2]](diffhunk://#diff-76b4955dbb1a185cbd0631d78538c22cddfd2333b5d8540d16d1d93de9bc7ddfR144-R157) [[3]](diffhunk://#diff-76b4955dbb1a185cbd0631d78538c22cddfd2333b5d8540d16d1d93de9bc7ddfR181-R182)
* Updated the `Import` method in `Role` to propagate errors from permission parsing, so that any issues during import are properly handled.

**Error propagation in resource operations:**

* Modified all CRUD and import operations in `resource.go` to check for errors from `Import` and report them as diagnostics, preventing state updates when permission parsing fails. [[1]](diffhunk://#diff-906cc2649b6073b93fa3c2084f37e379b44da121422a769137ccfca77b3002adL162-R169) [[2]](diffhunk://#diff-906cc2649b6073b93fa3c2084f37e379b44da121422a769137ccfca77b3002adL185-R199) [[3]](diffhunk://#diff-906cc2649b6073b93fa3c2084f37e379b44da121422a769137ccfca77b3002adL228-R249) [[4]](diffhunk://#diff-906cc2649b6073b93fa3c2084f37e379b44da121422a769137ccfca77b3002adL261-R289) [[5]](diffhunk://#diff-906cc2649b6073b93fa3c2084f37e379b44da121422a769137ccfca77b3002adL318-R353)

**Testing and documentation:**

* Added comprehensive unit tests in `model_test.go` to verify correct error handling and expected behavior for various permission payloads.
* Added a changelog entry documenting the improved permission handling.

**Other improvements:**

* Minor: Renamed `models.go` to `model.go` and fixed a comment typo (`parseContentValue` to `ParseContentValue`). [[1]](diffhunk://#diff-76b4955dbb1a185cbd0631d78538c22cddfd2333b5d8540d16d1d93de9bc7ddfL222-R234) [[2]](diffhunk://#diff-76b4955dbb1a185cbd0631d78538c22cddfd2333b5d8540d16d1d93de9bc7ddfR5)