### PR TITLE
fix: fixed issues with updating sidebar and editor on editor_interfac…

### DIFF
--- a/.changes/unreleased/Fixed-20250916-173649.yaml
+++ b/.changes/unreleased/Fixed-20250916-173649.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed issues with updating sidebar and editor on editor_interface resource
+time: 2025-09-16T17:36:49.306636575+02:00

--- a/internal/resources/editor_interface/model.go
+++ b/internal/resources/editor_interface/model.go
@@ -104,7 +104,7 @@ func (e *EditorInterface) ToUpdateBody() sdk.EditorInterfaceUpdate {
 		return sidebar
 	})
 
-	if len(sidebar) > 0 {
+	if sidebar != nil {
 		result.Sidebar = &sidebar
 	} else {
 		result.Sidebar = nil
@@ -132,7 +132,7 @@ func (e *EditorInterface) ToUpdateBody() sdk.EditorInterfaceUpdate {
 		return editor
 	})
 
-	if len(editors) > 0 {
+	if editors != nil {
 		result.Editors = &editors
 	} else {
 		result.Editors = nil

--- a/internal/resources/editor_interface/resource.go
+++ b/internal/resources/editor_interface/resource.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -163,9 +165,7 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 						"disabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Bool{
-								custommodifier.BoolDefault(false),
-							},
+							Default:  booldefault.StaticBool(false),
 						},
 						"widget_id": schema.StringAttribute{
 							Required: true,
@@ -194,9 +194,7 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 						"disabled": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Bool{
-								custommodifier.BoolDefault(false),
-							},
+							Default:  booldefault.StaticBool(false),
 						},
 						"widget_id": schema.StringAttribute{
 							Required: true,
@@ -213,6 +211,9 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 							},
 						},
 					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 10),
 				},
 			},
 		},

--- a/internal/resources/editor_interface/resource_test.go
+++ b/internal/resources/editor_interface/resource_test.go
@@ -70,6 +70,15 @@ func TestAccEditorInterfaceResource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "editors.0.widget_id", "default-editor"),
 				),
 			},
+			{
+				Config: testAccEditorInterfaceConfigUpdateWithEmptySideBarDefaultEditorEnabled(spaceID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContentfulEditorInterfaceExists(resourceName, &editorInterface),
+					resource.TestCheckResourceAttr(resourceName, "sidebar.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "editors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "editors.0.disabled", "false"),
+				),
+			},
 			// Test import
 			{
 				ResourceName:      resourceName,
@@ -271,6 +280,64 @@ resource "contentful_editor_interface" "test_editor_interface" {
       widget_namespace = "editor-builtin",
       widget_id = "default-editor",
       disabled = true
+    }
+  ]
+}
+`, spaceID)
+}
+
+func testAccEditorInterfaceConfigUpdateWithEmptySideBarDefaultEditorEnabled(spaceID string) string {
+	return fmt.Sprintf(`
+resource "contentful_contenttype" "test_contenttype" {
+  space_id     = "%s"
+  environment  = "master"
+  name         = "test-content-type"
+  description  = "Test Content Type for Editor Interface"
+  display_field = "title"
+
+	fields = [
+		{
+			id        = "title"
+			name      = "Title"
+			type      = "Symbol"
+			required  = true
+		},
+		{
+			id        = "description"
+			name      = "Description"
+			type      = "Text"
+			required  = false
+		}
+	]
+}
+
+resource "contentful_editor_interface" "test_editor_interface" {
+  space_id     = contentful_contenttype.test_contenttype.space_id
+  environment  = contentful_contenttype.test_contenttype.environment
+  content_type = contentful_contenttype.test_contenttype.id
+
+  controls = [
+    {
+      field_id = "title"
+      widget_id = "singleLine"
+      widget_namespace = "builtin"
+    },
+    {
+      field_id = "description"
+      widget_id = "richTextEditor"
+      widget_namespace = "builtin"
+      settings = {
+        help_text = "Rich text content"
+      }
+    }
+  ]
+	
+	sidebar = []
+	
+	  editors = [
+    {
+      widget_namespace = "editor-builtin",
+      widget_id = "default-editor"
     }
   ]
 }


### PR DESCRIPTION
This pull request addresses issues with updating the sidebar and editor sections in the `editor_interface` resource, ensuring correct handling of empty and default values. It also improves validation and test coverage for these scenarios.

**Bug fixes and logic improvements:**
* Changed sidebar and editors update logic in `model.go` to check for `nil` instead of length, preventing incorrect updates when these fields are empty. [[1]](diffhunk://#diff-081d8d2047af5174cf857776b5c000c9adfbc9cb54272fd0f3d41207ed277831L107-R107) [[2]](diffhunk://#diff-081d8d2047af5174cf857776b5c000c9adfbc9cb54272fd0f3d41207ed277831L135-R135)

**Schema and validation enhancements:**
* Replaced custom boolean default plan modifiers with the framework's `booldefault.StaticBool(false)` for the `disabled` attribute, simplifying and standardizing default handling. [[1]](diffhunk://#diff-32962931dd0647856ceec8de81ad55ff5df5eac381ef9c1e88cbf9425c76d987L166-R168) [[2]](diffhunk://#diff-32962931dd0647856ceec8de81ad55ff5df5eac381ef9c1e88cbf9425c76d987L197-R197)
* Added a list size validator to the `editors` attribute, enforcing that the list contains between 1 and 10 items.
* Updated imports to include new validators and default helpers.

**Test coverage improvements:**
* Added an acceptance test to verify correct behavior when updating with an empty sidebar and a default-enabled editor. [[1]](diffhunk://#diff-ed458766fa0aa5d16c9862f8b9ff3f51fc97391e0b68262a42e3260a98c3e19dR73-R81) [[2]](diffhunk://#diff-ed458766fa0aa5d16c9862f8b9ff3f51fc97391e0b68262a42e3260a98c3e19dR288-R345)

**Documentation:**
* Added a changelog entry describing the fix for sidebar and editor updates on the `editor_interface` resource.