### PR TITLE
fix: fixed typo in editor_interface controls datePicker

### DIFF
--- a/.changes/unreleased/Fixed-20250926-115051.yaml
+++ b/.changes/unreleased/Fixed-20250926-115051.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed typo in editor_interface controls datePicker
+time: 2025-09-26T11:50:51.67685759+02:00

--- a/internal/resources/editor_interface/resource.go
+++ b/internal/resources/editor_interface/resource.go
@@ -129,14 +129,14 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional: true,
 									Validators: []validator.String{
 										stringvalidator.OneOf("dateonly", "time", "timeZ"),
-										customvalidator.StringAllowedWhenSetValidator(widgetIdPath, "datepicker"),
+										customvalidator.StringAllowedWhenSetValidator(widgetIdPath, "datePicker"),
 									},
 								},
 								"ampm": schema.StringAttribute{
 									Optional: true,
 									Validators: []validator.String{
 										stringvalidator.OneOf("12", "24"),
-										customvalidator.StringAllowedWhenSetValidator(widgetIdPath, "datepicker"),
+										customvalidator.StringAllowedWhenSetValidator(widgetIdPath, "datePicker"),
 									},
 								},
 								/** (only for References, many) Select whether to enable Bulk Editing mode */

--- a/internal/resources/editor_interface/resource_test.go
+++ b/internal/resources/editor_interface/resource_test.go
@@ -21,6 +21,7 @@ import (
 func TestAccEditorInterfaceResource_Basic(t *testing.T) {
 	spaceID := os.Getenv("CONTENTFUL_SPACE_ID")
 	resourceName := "contentful_editor_interface.test_editor_interface"
+	resourceNameDatePicker := "contentful_editor_interface.test_editor_interface_datepicker"
 
 	var editorInterface sdk.EditorInterface
 
@@ -96,6 +97,23 @@ func TestAccEditorInterfaceResource_Basic(t *testing.T) {
 						rs.Primary.Attributes["content_type"],
 					), nil
 				},
+			},
+
+			// Test DatePicker widget
+			{
+				Config: testAccEditorInterfaceConfig_DatePicker(spaceID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContentfulEditorInterfaceExists(resourceNameDatePicker, &editorInterface),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "space_id", spaceID),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "environment", "master"),
+					resource.TestCheckResourceAttrSet(resourceNameDatePicker, "content_type"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.0.field_id", "date"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.0.widget_id", "datePicker"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.0.widget_namespace", "builtin"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.0.settings.ampm", "24"),
+					resource.TestCheckResourceAttr(resourceNameDatePicker, "controls.0.settings.format", "dateonly"),
+				),
 			},
 		},
 	})
@@ -338,6 +356,42 @@ resource "contentful_editor_interface" "test_editor_interface" {
     {
       widget_namespace = "editor-builtin",
       widget_id = "default-editor"
+    }
+  ]
+}
+`, spaceID)
+}
+
+func testAccEditorInterfaceConfig_DatePicker(spaceID string) string {
+	return fmt.Sprintf(`
+resource "contentful_contenttype" "test_contenttype_datepicker" {
+  space_id     = "%s"
+  environment  = "master"
+  id         	 = "test-content-type-datepicker"
+  name         = "test content type date picker"
+  description  = "Test Content Type for Editor Interface with Date Picker"
+  display_field = "date"
+
+	fields  = [
+		{
+			id        = "date"
+			name      = "Date"
+			type      = "Date"
+		}
+	]
+}
+
+resource "contentful_editor_interface" "test_editor_interface_datepicker" {
+  space_id     = contentful_contenttype.test_contenttype_datepicker.space_id
+  environment  = contentful_contenttype.test_contenttype_datepicker.environment
+  content_type = contentful_contenttype.test_contenttype_datepicker.id
+
+  controls = [
+    {
+      field_id         = "date"
+      widget_id        = "datePicker"
+      widget_namespace = "builtin",
+      settings         = { ampm : "24", format : "dateonly" }
     }
   ]
 }


### PR DESCRIPTION
This pull request fixes a typo in the `editor_interface` resource, ensuring consistent usage of `datePicker` instead of `datepicker`. Additionally, it introduces a new acceptance test to verify the correct handling of the `datePicker` widget in editor interface controls.

**Bug fix:**

* Corrected the spelling of `datePicker` in custom validators for the `format` and `ampm` settings in the `editor_interface` resource schema (`resource.go`).

**Testing improvements:**

* Added a new acceptance test `TestAccEditorInterfaceResource_DatePicker` to verify that the editor interface correctly supports the `datePicker` widget, including its settings (`resource_test.go`).
* Introduced a new test configuration function `testAccEditorInterfaceConfig_DatePicker` to set up resources for the new test, ensuring coverage for the `datePicker` widget scenario (`resource_test.go`).

**Documentation:**

* Added a changelog entry describing the typo fix in editor interface controls for `datePicker` (`.changes/unreleased/Fixed-20250926-115051.yaml`).