### PR TITLE
feat: additional properties in editor_interface

### DIFF
--- a/internal/custommodifier/stringdefault.go
+++ b/internal/custommodifier/stringdefault.go
@@ -26,9 +26,9 @@ func (m stringDefaultModifier) MarkdownDescription(ctx context.Context) string {
 	return m.Description(ctx)
 }
 
-func (m stringDefaultModifier) PlanModifyString(_ context.Context, _ planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// If the value is unknown or known, do not set default value.
-	if resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown() {
+func (m stringDefaultModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If the value is not configured, set default value.
+	if req.ConfigValue.IsNull() {
 		resp.PlanValue = types.StringValue(m.Default)
 	}
 }

--- a/internal/resources/editor_interface/model.go
+++ b/internal/resources/editor_interface/model.go
@@ -48,14 +48,15 @@ type Control struct {
 }
 
 type Settings struct {
-	HelpText        types.String `tfsdk:"help_text"`
-	TrueLabel       types.String `tfsdk:"true_label"`
-	FalseLabel      types.String `tfsdk:"false_label"`
-	Stars           types.Int64  `tfsdk:"stars"`
-	Format          types.String `tfsdk:"format"`
-	TimeFormat      types.String `tfsdk:"ampm"`
-	BulkEditing     types.Bool   `tfsdk:"bulk_editing"`
-	TrackingFieldId types.String `tfsdk:"tracking_field_id"`
+	HelpText             types.String         `tfsdk:"help_text"`
+	TrueLabel            types.String         `tfsdk:"true_label"`
+	FalseLabel           types.String         `tfsdk:"false_label"`
+	Stars                types.Int64          `tfsdk:"stars"`
+	Format               types.String         `tfsdk:"format"`
+	TimeFormat           types.String         `tfsdk:"ampm"`
+	BulkEditing          types.Bool           `tfsdk:"bulk_editing"`
+	TrackingFieldId      types.String         `tfsdk:"tracking_field_id"`
+	AdditionalProperties jsontypes.Normalized `tfsdk:"additional_properties"`
 }
 
 // ToUpdateBody converts the EditorInterface to an SDK update request body
@@ -234,6 +235,17 @@ func (s *Settings) Import(settings *sdk.EditorInterfaceSettings) {
 	s.TimeFormat = types.StringPointerValue(settings.Ampm)
 	s.BulkEditing = types.BoolPointerValue(settings.BulkEditing)
 	s.TrackingFieldId = types.StringPointerValue(settings.TrackingFieldId)
+
+	if len(settings.AdditionalProperties) > 0 {
+		jsonData, err := json.Marshal(settings.AdditionalProperties)
+		if err == nil {
+			s.AdditionalProperties = jsontypes.NewNormalizedValue(string(jsonData))
+		} else {
+			s.AdditionalProperties = jsontypes.NewNormalizedValue("{}")
+		}
+	} else {
+		s.AdditionalProperties = jsontypes.NewNormalizedValue("{}")
+	}
 }
 
 func (s *Settings) Draft() *sdk.EditorInterfaceSettings {
@@ -250,5 +262,14 @@ func (s *Settings) Draft() *sdk.EditorInterfaceSettings {
 	settings.Ampm = s.TimeFormat.ValueStringPointer()
 	settings.BulkEditing = s.BulkEditing.ValueBoolPointer()
 	settings.TrackingFieldId = s.TrackingFieldId.ValueStringPointer()
+
+	if !s.AdditionalProperties.IsNull() && !s.AdditionalProperties.IsUnknown() {
+		var additionalProps map[string]interface{}
+		err := s.AdditionalProperties.Unmarshal(&additionalProps)
+		if err == nil {
+			settings.AdditionalProperties = additionalProps
+		}
+	}
+
 	return settings
 }

--- a/internal/resources/editor_interface/resource.go
+++ b/internal/resources/editor_interface/resource.go
@@ -149,6 +149,15 @@ func (e *editorInterfaceResource) Schema(_ context.Context, _ resource.SchemaReq
 										customvalidator.StringAllowedWhenSetValidator(widgetIdPath, "slugEditor"),
 									},
 								},
+								"additional_properties": schema.StringAttribute{
+									CustomType:  jsontypes.NormalizedType{},
+									Optional:    true,
+									Computed:    true,
+									Description: "Additional widget-specific settings as JSON. Supports complex types like arrays and objects.",
+									PlanModifiers: []planmodifier.String{
+										custommodifier.StringDefault("{}"),
+									},
+								},
 							},
 							Optional: true,
 							PlanModifiers: []planmodifier.Object{


### PR DESCRIPTION
This PR adds support for `additional_properties` in editor interface control settings. This field allows passing widget-specific settings as JSON, supporting complex data types like arrays and objects that weren't previously supported by the individual typed fields (`help_text`, `true_label`, `stars`, etc.).

The implementation:
 - Adds an `additional_properties` field to the control settings schema as a JSON-normalized string
 - Handles marshaling/unmarshaling of the additional properties during Import and Draft operations
 - Uses a default value of `{}` when no additional properties are provided
 - Maintains backward compatibility with existing control settings

Solves issue https://github.com/labd/terraform-provider-contentful/issues/138