### PR TITLE
fix: correct role resource version assignment and update read state

### DIFF
--- a/.changes/unreleased/Fixed-20260220-150351.yaml
+++ b/.changes/unreleased/Fixed-20260220-150351.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed setting read state on role resource
+time: 2026-02-20T15:03:51.760407775+01:00

--- a/internal/resources/role/model.go
+++ b/internal/resources/role/model.go
@@ -45,7 +45,7 @@ func (r *Role) Import(role *sdk.Role) error {
 	r.ID = types.StringValue(role.Sys.Id)
 	r.RoleId = types.StringValue(role.Sys.Id)
 	r.SpaceID = types.StringValue(role.Sys.Space.Sys.Id)
-	r.Version = types.Int64Value(int64(role.Sys.Version))
+	r.Version = types.Int64Value(role.Sys.Version)
 	r.Name = types.StringValue(role.Name)
 	r.Description = types.StringValue(role.Description)
 

--- a/internal/resources/role/resource.go
+++ b/internal/resources/role/resource.go
@@ -198,7 +198,7 @@ func (e *roleResource) Read(ctx context.Context, request resource.ReadRequest, r
 		return
 	}
 
-	response.Diagnostics.Append(request.State.Set(ctx, &state)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
 func (e *roleResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {


### PR DESCRIPTION
This pull request addresses a bug with setting the read state on the role resource, ensuring correct state management and fixing a minor type conversion. The most important changes are:

Bug Fixes to Role Resource State Management:
* Fixed an issue in the `Read` method of `roleResource` by setting state on `response.State` instead of `request.State`, ensuring the resource state is correctly updated during read operations (`internal/resources/role/resource.go`).
* Added a changelog entry documenting the fix for setting the read state on the role resource (`.changes/unreleased/Fixed-20260220-150351.yaml`).

Minor Code Correction:
* Removed an unnecessary type conversion when setting the `Version` field in the `Import` method of the `Role` model, using `role.Sys.Version` directly (`internal/resources/role/model.go`).