### PR TITLE
Fix false-positive "Empty default_value" error when using variables as map keys

### DIFF
--- a/internal/customvalidator/defaultvaluestructurevalidator.go
+++ b/internal/customvalidator/defaultvaluestructurevalidator.go
@@ -13,7 +13,7 @@ type DefaultValueStructureValidator struct{}
 
 // Description returns a description of the validator.
 func (v DefaultValueStructureValidator) Description(_ context.Context) string {
-	return "Validates that default_value has the correct structure with 'string' or 'bool' keys"
+	return "Validates that default_value has the correct structure with 'string', 'bool' or 'array' keys"
 }
 
 // MarkdownDescription returns a markdown description of the validator.
@@ -49,7 +49,7 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 				"Invalid default_value structure",
 				fmt.Sprintf("Found unexpected attribute '%s' in default_value. "+
 					"The correct syntax is: default_value = { string = { \"%s\" = \"value\" } } "+
-					"or default_value = { bool = { \"%s\" = true } }"+
+					"or default_value = { bool = { \"%s\" = true } } "+
 					"or default_value = { array = { \"%s\" = [\"value1\", \"value2\"] } }", firstKey, firstKey, firstKey, firstKey),
 			)
 			return
@@ -58,8 +58,8 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 			request.Path,
 			"Invalid default_value structure",
 			"default_value must contain either 'string', 'bool' or 'array' attribute. "+
-				"Example: default_value = { string = { \"en-US\" = \"green\" } }"+
-				"or default_value = { bool = { \"en-US\" = true } }"+
+				"Example: default_value = { string = { \"en-US\" = \"green\" } } "+
+				"or default_value = { bool = { \"en-US\" = true } } "+
 				"or default_value = { array = { \"en-US\" = [\"value1\", \"value2\"] } }",
 		)
 		return
@@ -77,32 +77,32 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 	boolHasContent := false
 	arrayHasContent := false
 
-	if hasString && !stringAttr.IsNull() && !stringAttr.IsUnknown() {
+	if hasString && !stringAttr.IsNull() {
 		if stringMap, ok := stringAttr.(types.Map); ok && len(stringMap.Elements()) > 0 {
 			stringHasContent = true
 		}
 	}
 
-	if hasBool && !boolAttr.IsNull() && !boolAttr.IsUnknown() {
+	if hasBool && !boolAttr.IsNull() {
 		if boolMap, ok := boolAttr.(types.Map); ok && len(boolMap.Elements()) > 0 {
 			boolHasContent = true
 		}
 	}
 
-	if hasArray && !arrayAttr.IsNull() && !arrayAttr.IsUnknown() {
+	if hasArray && !arrayAttr.IsNull() {
 		if arrayMap, ok := arrayAttr.(types.Map); ok && len(arrayMap.Elements()) > 0 {
 			arrayHasContent = true
 		}
 	}
 
-	// If we have string/bool/array/int attributes but they're all empty, that's an error
+	// If we have string/bool/array attributes but they're all empty, that's an error
 	if !stringHasContent && !boolHasContent && !arrayHasContent && (hasString || hasBool || hasArray) {
 		response.Diagnostics.AddAttributeError(
 			request.Path,
 			"Empty default_value",
 			"default_value must contain actual values. "+
-				"Example: default_value = { string = { \"en-US\" = \"green\" } }"+
-				"or default_value = { bool = { \"en-US\" = true } }"+
+				"Example: default_value = { string = { \"en-US\" = \"green\" } } "+
+				"or default_value = { bool = { \"en-US\" = true } } "+
 				"or default_value = { array = { \"en-US\" = [\"value1\", \"value2\"] } }",
 		)
 	}

--- a/internal/customvalidator/defaultvaluestructurevalidator.go
+++ b/internal/customvalidator/defaultvaluestructurevalidator.go
@@ -29,7 +29,7 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 
 	attributes := request.ConfigValue.Attributes()
 
-	// Check if both string and bool are null/empty
+	// Check if string, bool and array are null/empty
 	stringAttr, hasString := attributes["string"]
 	boolAttr, hasBool := attributes["bool"]
 	arrayAttr, hasArray := attributes["array"]
@@ -49,16 +49,26 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 				"Invalid default_value structure",
 				fmt.Sprintf("Found unexpected attribute '%s' in default_value. "+
 					"The correct syntax is: default_value = { string = { \"%s\" = \"value\" } } "+
-					"or default_value = { bool = { \"%s\" = true } }", firstKey, firstKey, firstKey),
+					"or default_value = { bool = { \"%s\" = true } }"+
+					"or default_value = { array = { \"%s\" = [\"value1\", \"value2\"] } }", firstKey, firstKey, firstKey, firstKey),
 			)
 			return
 		}
 		response.Diagnostics.AddAttributeError(
 			request.Path,
 			"Invalid default_value structure",
-			"default_value must contain either 'string' or 'bool' attribute. "+
-				"Example: default_value = { string = { \"en-US\" = \"green\" } }",
+			"default_value must contain either 'string', 'bool' or 'array' attribute. "+
+				"Example: default_value = { string = { \"en-US\" = \"green\" } }"+
+				"or default_value = { bool = { \"en-US\" = true } }"+
+				"or default_value = { array = { \"en-US\" = [\"value1\", \"value2\"] } }",
 		)
+		return
+	}
+
+	// If any attribute is unknown (e.g. a variable is used as a map key),
+	// we cannot validate the content at this stage. Skip validation and let
+	// Terraform resolve the values first.
+	if (hasString && stringAttr.IsUnknown()) || (hasBool && boolAttr.IsUnknown()) || (hasArray && arrayAttr.IsUnknown()) {
 		return
 	}
 
@@ -85,13 +95,15 @@ func (v DefaultValueStructureValidator) ValidateObject(ctx context.Context, requ
 		}
 	}
 
-	// If we have string/bool attributes but they're both empty, that's an error
+	// If we have string/bool/array/int attributes but they're all empty, that's an error
 	if !stringHasContent && !boolHasContent && !arrayHasContent && (hasString || hasBool || hasArray) {
 		response.Diagnostics.AddAttributeError(
 			request.Path,
 			"Empty default_value",
 			"default_value must contain actual values. "+
-				"Example: default_value = { string = { \"en-US\" = \"green\" } }",
+				"Example: default_value = { string = { \"en-US\" = \"green\" } }"+
+				"or default_value = { bool = { \"en-US\" = true } }"+
+				"or default_value = { array = { \"en-US\" = [\"value1\", \"value2\"] } }",
 		)
 	}
 }

--- a/internal/customvalidator/defaultvaluestructurevalidator_test.go
+++ b/internal/customvalidator/defaultvaluestructurevalidator_test.go
@@ -1,13 +1,160 @@
 package customvalidator
 
 import (
+	"context"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 func TestDefaultValueStructureValidator_Creation(t *testing.T) {
 	// Basic test to ensure the validator can be created
-	validator := DefaultValueStructure()
-	if validator == nil {
+	v := DefaultValueStructure()
+	if v == nil {
 		t.Error("DefaultValueStructure() should not return nil")
+	}
+}
+
+// defaultValueAttrTypes returns the attribute types for the default_value object,
+// matching the schema definition in contenttype/resource.go.
+func defaultValueAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"string": types.MapType{ElemType: types.StringType},
+		"bool":   types.MapType{ElemType: types.BoolType},
+		"array":  types.MapType{ElemType: types.ListType{ElemType: types.StringType}},
+	}
+}
+
+func runValidator(t *testing.T, configValue basetypes.ObjectValue) diag.Diagnostics {
+	t.Helper()
+	ctx := context.Background()
+	v := DefaultValueStructureValidator{}
+	request := validator.ObjectRequest{
+		Path:        path.Root("default_value"),
+		ConfigValue: configValue,
+	}
+	response := &validator.ObjectResponse{}
+	v.ValidateObject(ctx, request, response)
+	return response.Diagnostics
+}
+
+func TestValidateObject_NullObject(t *testing.T) {
+	configValue := types.ObjectNull(defaultValueAttrTypes())
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for null object, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_UnknownObject(t *testing.T) {
+	configValue := types.ObjectUnknown(defaultValueAttrTypes())
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for unknown object, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_ValidStringMap(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapValueMust(types.StringType, map[string]attr.Value{
+			"en-US": types.StringValue("green"),
+		}),
+		"bool":  types.MapNull(types.BoolType),
+		"array": types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for valid string map, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_ValidBoolMap(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapNull(types.StringType),
+		"bool": types.MapValueMust(types.BoolType, map[string]attr.Value{
+			"en-US": types.BoolValue(true),
+		}),
+		"array": types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for valid bool map, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_EmptyStringMap_Error(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		"bool":   types.MapNull(types.BoolType),
+		"array":  types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if !diags.HasError() {
+		t.Error("expected error for empty string map, got none")
+	}
+	found := false
+	for _, d := range diags.Errors() {
+		if d.Summary() == "Empty default_value" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Empty default_value' error, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_AllNullMaps_Error(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapNull(types.StringType),
+		"bool":   types.MapNull(types.BoolType),
+		"array":  types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if !diags.HasError() {
+		t.Error("expected error when all maps are null, got none")
+	}
+}
+
+func TestValidateObject_UnknownStringMap_NoError(t *testing.T) {
+	// Simulates a variable used as a map key: default_value = { string = { (var.locale) = "value" } }
+	// The framework marks the entire map as unknown when it cannot resolve the key at validation time.
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapUnknown(types.StringType),
+		"bool":   types.MapNull(types.BoolType),
+		"array":  types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for unknown string map (variable as key), got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_UnknownBoolMap_NoError(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapNull(types.StringType),
+		"bool":   types.MapUnknown(types.BoolType),
+		"array":  types.MapNull(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for unknown bool map, got: %v", diags.Errors())
+	}
+}
+
+func TestValidateObject_UnknownArrayMap_NoError(t *testing.T) {
+	configValue := types.ObjectValueMust(defaultValueAttrTypes(), map[string]attr.Value{
+		"string": types.MapNull(types.StringType),
+		"bool":   types.MapNull(types.BoolType),
+		"array":  types.MapUnknown(types.ListType{ElemType: types.StringType}),
+	})
+	diags := runValidator(t, configValue)
+	if diags.HasError() {
+		t.Errorf("expected no errors for unknown array map, got: %v", diags.Errors())
 	}
 }


### PR DESCRIPTION
## Problem

Using a variable as a map key in `default_value` causes a false-positive
validation error during plan:

```hcl
default_value = { string = { (var.default_locale) = "article" } }
│ Error: Empty default_value
│
│ default_value must contain actual values. Example: default_value = { string
│ = { "en-US" = "green" } }
```
When a variable or expression is used as a map key, the Terraform Plugin
Framework marks the map attribute as unknown during validation. The validator
treated unknown maps as empty, triggering this error even though the value
clearly has content.
## Fix
Added an early return in DefaultValueStructureValidator.ValidateObject that
skips validation when any map attribute (string, bool, or array) is
unknown. The value will be validated at apply time when it is fully resolved.
Also updated error messages to mention the array attribute type alongside
string and bool.
## Tests
Added unit tests covering:
- Unknown string/bool/array maps produce no errors (the reported bug)
- Known maps with content pass validation
- Empty and null maps still correctly trigger errors